### PR TITLE
Use namespaced stdlib function

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,7 +62,7 @@ class cis_security_hardening (
       'suse'  => 'absent',
       default => 'purged',
     }
-    ensure_packages(['authconfig'], {
+    stdlib::ensure_packages(['authconfig'], {
         ensure => $ensure,
     })
   }

--- a/manifests/rules/abrt.pp
+++ b/manifests/rules/abrt.pp
@@ -36,7 +36,7 @@ class cis_security_hardening::rules::abrt (
         default => 'purged',
       }
 
-      ensure_packages($pkgs, {
+      stdlib::ensure_packages($pkgs, {
           ensure => $ensure,
       })
     }

--- a/manifests/rules/aide_installed.pp
+++ b/manifests/rules/aide_installed.pp
@@ -28,8 +28,8 @@ class cis_security_hardening::rules::aide_installed (
   if $enforce {
     case $facts['os']['name'].downcase() {
       'ubuntu', 'debian': {
-        ensure_packages(['aide', 'aide-common'], {
-            ensure => installed,
+        stdlib::ensure_packages(['aide', 'aide-common'], { 
+            ensure => 'installed',
             notify => Exec['aidedb-ubuntu-init'],
         })
 
@@ -53,11 +53,11 @@ class cis_security_hardening::rules::aide_installed (
         }
       }
       'centos', 'redhat', 'almalinux', 'rocky': {
-        ensure_packages(['aide'], {
-            ensure => installed,
+        stdlib::ensure_packages(['aide'], { 
+            ensure => 'installed',
             notify => Exec['aidedb'],
         })
-
+        
         exec { 'aidedb':
           command     => 'aide --init',
           path        => ['/sbin', '/usr/sbin', '/bin', '/usr/bin'],
@@ -76,8 +76,8 @@ class cis_security_hardening::rules::aide_installed (
         }
       }
       'sles': {
-        ensure_packages(['aide'], {
-            ensure => installed,
+        stdlib::ensure_packages(['aide'], { 
+            ensure => 'installed',
             notify => Exec['aidedb'],
         })
 

--- a/manifests/rules/aide_installed.pp
+++ b/manifests/rules/aide_installed.pp
@@ -29,7 +29,7 @@ class cis_security_hardening::rules::aide_installed (
     case $facts['os']['name'].downcase() {
       'ubuntu', 'debian': {
         stdlib::ensure_packages(['aide', 'aide-common'], {
-            ensure => 'installed',
+            ensure => installed,
             notify => Exec['aidedb-ubuntu-init'],
         })
 
@@ -54,7 +54,7 @@ class cis_security_hardening::rules::aide_installed (
       }
       'centos', 'redhat', 'almalinux', 'rocky': {
         stdlib::ensure_packages(['aide'], {
-            ensure => 'installed',
+            ensure => installed,
             notify => Exec['aidedb'],
         })
 
@@ -77,7 +77,7 @@ class cis_security_hardening::rules::aide_installed (
       }
       'sles': {
         stdlib::ensure_packages(['aide'], {
-            ensure => 'installed',
+            ensure => installed,
             notify => Exec['aidedb'],
         })
 

--- a/manifests/rules/aide_installed.pp
+++ b/manifests/rules/aide_installed.pp
@@ -28,7 +28,7 @@ class cis_security_hardening::rules::aide_installed (
   if $enforce {
     case $facts['os']['name'].downcase() {
       'ubuntu', 'debian': {
-        stdlib::ensure_packages(['aide', 'aide-common'], { 
+        stdlib::ensure_packages(['aide', 'aide-common'], {
             ensure => 'installed',
             notify => Exec['aidedb-ubuntu-init'],
         })
@@ -53,11 +53,11 @@ class cis_security_hardening::rules::aide_installed (
         }
       }
       'centos', 'redhat', 'almalinux', 'rocky': {
-        stdlib::ensure_packages(['aide'], { 
+        stdlib::ensure_packages(['aide'], {
             ensure => 'installed',
             notify => Exec['aidedb'],
         })
-        
+
         exec { 'aidedb':
           command     => 'aide --init',
           path        => ['/sbin', '/usr/sbin', '/bin', '/usr/bin'],
@@ -76,7 +76,7 @@ class cis_security_hardening::rules::aide_installed (
         }
       }
       'sles': {
-        stdlib::ensure_packages(['aide'], { 
+        stdlib::ensure_packages(['aide'], {
             ensure => 'installed',
             notify => Exec['aidedb'],
         })

--- a/manifests/rules/apparmor.pp
+++ b/manifests/rules/apparmor.pp
@@ -22,7 +22,7 @@ class cis_security_hardening::rules::apparmor (
   if $enforce {
     case $facts['os']['family'].downcase() {
       'debian': {
-        ensure_packages(['apparmor-utils', 'apparmor'], {
+        stdlib::ensure_packages(['apparmor-utils', 'apparmor'], {
             ensure => present,
         })
       }

--- a/manifests/rules/auditd_package.pp
+++ b/manifests/rules/auditd_package.pp
@@ -27,7 +27,7 @@ class cis_security_hardening::rules::auditd_package (
 ) {
   if $enforce {
     $packages.each |$pkg| {
-      ensure_packages([$pkg], {
+      stdlib::ensure_packages([$pkg], {
           ensure => installed,
       })
     }

--- a/manifests/rules/auditd_rsyslog_gnutls.pp
+++ b/manifests/rules/auditd_rsyslog_gnutls.pp
@@ -33,7 +33,7 @@ class cis_security_hardening::rules::auditd_rsyslog_gnutls (
   Boolean $enforce = false,
 ) {
   if $enforce {
-    ensure_packages(['rsyslog-gnutls'], {
+    stdlib::ensure_packages(['rsyslog-gnutls'], {
         ensure => installed,
     })
   }

--- a/manifests/rules/automatic_error_reporting.pp
+++ b/manifests/rules/automatic_error_reporting.pp
@@ -41,7 +41,7 @@ class cis_security_hardening::rules::automatic_error_reporting (
         default => 'purged',
       }
 
-      ensure_packages(['apport'], {
+      stdlib::ensure_packages(['apport'], {
           ensure => $ensure,
       })
     }

--- a/manifests/rules/avahi.pp
+++ b/manifests/rules/avahi.pp
@@ -55,7 +55,7 @@ class cis_security_hardening::rules::avahi (
             ensure => 'stopped',
             enable => false,
         })
-        ensure_packages(['avahi-autoipd', 'avahi'], {
+        stdlib::ensure_packages(['avahi-autoipd', 'avahi'], {
             ensure => $ensure,
         })
       }
@@ -68,7 +68,7 @@ class cis_security_hardening::rules::avahi (
             ensure => 'stopped',
             enable => false,
         })
-        ensure_packages(['avahi-daemon'], {
+        stdlib::ensure_packages(['avahi-daemon'], {
             ensure => $ensure,
         })
       }
@@ -89,7 +89,7 @@ class cis_security_hardening::rules::avahi (
             unless  => "test \"$(systemctl is-active avahi-daemon.socket)\" = \"inactive\"",
           }
 
-          ensure_packages(['avahi-daemon'], {
+          stdlib::ensure_packages(['avahi-daemon'], {
               ensure => $ensure,
               require => [Exec['stop avahi service'], Exec['stop avahi socket']]
           })
@@ -109,7 +109,7 @@ class cis_security_hardening::rules::avahi (
             ensure => 'stopped',
             enable => false,
         })
-        ensure_packages(['avahi-autoipd', 'avahi'], {
+        stdlib::ensure_packages(['avahi-autoipd', 'avahi'], {
             ensure => $ensure,
         })
       }

--- a/manifests/rules/bind.pp
+++ b/manifests/rules/bind.pp
@@ -36,7 +36,7 @@ class cis_security_hardening::rules::bind (
       }
     }
 
-    ensure_packages($pkgs, {
+    stdlib::ensure_packages($pkgs, {
         ensure => $ensure,
     })
   }

--- a/manifests/rules/chrony.pp
+++ b/manifests/rules/chrony.pp
@@ -53,7 +53,7 @@ class cis_security_hardening::rules::chrony (
 
     case $facts['os']['name'].downcase() {
       'ubuntu': {
-        ensure_packages(['ntp'], {
+        stdlib::ensure_packages(['ntp'], {
             ensure => purged,
         })
       }

--- a/manifests/rules/crond_service.pp
+++ b/manifests/rules/crond_service.pp
@@ -34,7 +34,7 @@ class cis_security_hardening::rules::crond_service (
     }
 
     if $uninstall_cron {
-      ensure_packages(['cronie'], {
+      stdlib::ensure_packages(['cronie'], {
           ensure => $ensure,
       })
     } else {

--- a/manifests/rules/cups.pp
+++ b/manifests/rules/cups.pp
@@ -29,18 +29,18 @@ class cis_security_hardening::rules::cups (
 
     case $facts['os']['name'].downcase() {
       'ubuntu', 'sles': {
-        ensure_packages(['cups'], {
+        stdlib::ensure_packages(['cups'], {
             ensure => $ensure,
         })
       }
       'rocky', 'almalinux': {
-        ensure_packages(['cups'], {
+        stdlib::ensure_packages(['cups'], {
             ensure => $ensure,
         })
       }
       'debian': {
         if $facts['os']['release']['major'] > '10' {
-          ensure_packages('cups', {
+          stdlib::ensure_packages('cups', {
               ensure => $ensure,
           })
         } else {

--- a/manifests/rules/dhcp.pp
+++ b/manifests/rules/dhcp.pp
@@ -22,7 +22,7 @@ class cis_security_hardening::rules::dhcp (
   if $enforce {
     case $facts['os']['name'].downcase() {
       'ubuntu': {
-        ensure_packages(['isc-dhcp-server'], {
+        stdlib::ensure_packages(['isc-dhcp-server'], {
             ensure => purged,
         })
       }
@@ -37,7 +37,7 @@ class cis_security_hardening::rules::dhcp (
         })
       }
       'sles': {
-        ensure_packages(['dhcp'], {
+        stdlib::ensure_packages(['dhcp'], {
             ensure => absent,
         })
       }

--- a/manifests/rules/disable_apport.pp
+++ b/manifests/rules/disable_apport.pp
@@ -36,7 +36,7 @@ class cis_security_hardening::rules::disable_apport (
         'suse'  => 'absent',
         default => 'purged',
       }
-      ensure_packages('apport', {
+      stdlib::ensure_packages('apport', {
           ensure => $ensure,
       })
     }

--- a/manifests/rules/disable_bluetooth.pp
+++ b/manifests/rules/disable_bluetooth.pp
@@ -64,7 +64,7 @@ class cis_security_hardening::rules::disable_bluetooth (
           ensure => 'stopped',
           enable => false,
         }
-        ensure_packages(['bluez'], {
+        stdlib::ensure_packages(['bluez'], {
             ensure => absent,
         })
       }

--- a/manifests/rules/disable_prelink.pp
+++ b/manifests/rules/disable_prelink.pp
@@ -28,7 +28,7 @@ class cis_security_hardening::rules::disable_prelink (
       default => 'purged',
     }
 
-    ensure_packages(['prelink'], {
+    stdlib::ensure_packages(['prelink'], {
         ensure => $ensure,
     })
 

--- a/manifests/rules/disable_wireless.pp
+++ b/manifests/rules/disable_wireless.pp
@@ -33,7 +33,7 @@ class cis_security_hardening::rules::disable_wireless (
     }
 
     if !empty($pkg) {
-      ensure_packages($pkg, {
+      stdlib::ensure_packages($pkg, {
           ensure => present,
       })
     }

--- a/manifests/rules/dnsmasq.pp
+++ b/manifests/rules/dnsmasq.pp
@@ -22,13 +22,13 @@ class cis_security_hardening::rules::dnsmasq (
   if $enforce {
     case $facts['os']['name'].downcase() {
       'redhat', 'centos': {
-        ensure_packages(['dnsmasq'], {
+        stdlib::ensure_packages(['dnsmasq'], {
             ensure => purged,
         })
       }
       'debian': {
         if $facts['os']['release']['major'] >= '12' {
-          ensure_packages(['dnsmasq'], {
+          stdlib::ensure_packages(['dnsmasq'], {
               ensure => purged,
           })
         }

--- a/manifests/rules/dovecot.pp
+++ b/manifests/rules/dovecot.pp
@@ -22,21 +22,21 @@ class cis_security_hardening::rules::dovecot (
   if $enforce {
     case $facts['os']['name'].downcase() {
       'ubuntu': {
-        ensure_packages(['dovecot-imapd', 'dovecot-pop3d'], {
+        stdlib::ensure_packages(['dovecot-imapd', 'dovecot-pop3d'], {
             ensure => purged,
         })
       }
       'sles': {
-        ensure_packages(['dovecot'], {
+        stdlib::ensure_packages(['dovecot'], {
             ensure => absent,
         })
       }
       'redhat': {
-        ensure_packages(['dovecot'], {
+        stdlib::ensure_packages(['dovecot'], {
             ensure => purged,
         })
 
-        ensure_packages(['cyrus-imapd'], {
+        stdlib::ensure_packages(['cyrus-imapd'], {
             ensure => purged,
         })
       }

--- a/manifests/rules/dracut_fips.pp
+++ b/manifests/rules/dracut_fips.pp
@@ -25,7 +25,7 @@ class cis_security_hardening::rules::dracut_fips (
   Boolean $enforce = false,
 ) {
   if $enforce {
-    ensure_packages(['dracut-fips'], {
+    stdlib::ensure_packages(['dracut-fips'], {
         ensure => installed,
         notify => Exec['recreate initramfs'],
     })

--- a/manifests/rules/fapolicyd.pp
+++ b/manifests/rules/fapolicyd.pp
@@ -38,7 +38,7 @@ class cis_security_hardening::rules::fapolicyd (
   String $gid      = 'users',
 ) {
   if $enforce {
-    ensure_packages(['fapolicyd'], {
+    stdlib::ensure_packages(['fapolicyd'], {
         ensure => 'installed',
     })
 

--- a/manifests/rules/firewalld_install.pp
+++ b/manifests/rules/firewalld_install.pp
@@ -46,7 +46,7 @@ class cis_security_hardening::rules::firewalld_install (
       default => ['nftables', 'iptables-services'],
     }
 
-    ensure_packages($pkgs, {
+    stdlib::ensure_packages($pkgs, {
         ensure => installed,
     })
 
@@ -55,7 +55,7 @@ class cis_security_hardening::rules::firewalld_install (
       default => 'purged',
     }
 
-    ensure_packages($pkgs_remove, {
+    stdlib::ensure_packages($pkgs_remove, {
         ensure => $ensure,
     })
 

--- a/manifests/rules/ftp.pp
+++ b/manifests/rules/ftp.pp
@@ -25,7 +25,7 @@ class cis_security_hardening::rules::ftp (
       'suse'  => 'absent',
       default => 'purged',
     }
-    ensure_packages(['ftp'], {
+    stdlib::ensure_packages(['ftp'], {
         ensure => $ensure,
     })
   }

--- a/manifests/rules/gdm_auto_mount.pp
+++ b/manifests/rules/gdm_auto_mount.pp
@@ -26,7 +26,7 @@ class cis_security_hardening::rules::gdm_auto_mount (
 ) {
   $gnome_gdm = fact('cis_security_hardening.gnome_gdm')
   if  $enforce and $gnome_gdm != undef and $gnome_gdm {
-    ensure_packages(['dconf'], {
+    stdlib::ensure_packages(['dconf'], {
         ensure => present,
     })
 

--- a/manifests/rules/gnome_gdm_package.pp
+++ b/manifests/rules/gnome_gdm_package.pp
@@ -30,7 +30,7 @@ class cis_security_hardening::rules::gnome_gdm_package (
       }
     }
 
-    ensure_packages($pkg, {
+    stdlib::ensure_packages($pkg, {
         ensure => $ensure,
     })
   }

--- a/manifests/rules/gssproxy.pp
+++ b/manifests/rules/gssproxy.pp
@@ -30,7 +30,7 @@ class cis_security_hardening::rules::gssproxy (
       'suse'  => 'absent',
       default => 'purged',
     }
-    ensure_packages(['gssproxy'], {
+    stdlib::ensure_packages(['gssproxy'], {
         ensure => $ensure,
     })
   }

--- a/manifests/rules/httpd.pp
+++ b/manifests/rules/httpd.pp
@@ -22,22 +22,22 @@ class cis_security_hardening::rules::httpd (
   if $enforce {
     case $facts['os']['name'].downcase() {
       'ubuntu', 'debian': {
-        ensure_packages(['apache2'], {
+        stdlib::ensure_packages(['apache2'], {
             ensure => purged,
         })
       }
       'sles': {
-        ensure_packages(['httpd'], {
+        stdlib::ensure_packages(['httpd'], {
             ensure => absent,
         })
       }
       'redhat': {
         if $facts['os']['release']['major'] >= '9' {
-          ensure_packages(['nginx'], {
+          stdlib::ensure_packages(['nginx'], {
               ensure => purged,
           })
         }
-        ensure_packages(['httpd'], {
+        stdlib::ensure_packages(['httpd'], {
             ensure => purged,
         })
       }

--- a/manifests/rules/iprutils.pp
+++ b/manifests/rules/iprutils.pp
@@ -32,7 +32,7 @@ class cis_security_hardening::rules::iprutils (
       default => 'purged',
     }
 
-    ensure_packages(['iprutils'], {
+    stdlib::ensure_packages(['iprutils'], {
         ensure => $ensure,
     })
   }

--- a/manifests/rules/iptables_install.pp
+++ b/manifests/rules/iptables_install.pp
@@ -42,7 +42,7 @@ class cis_security_hardening::rules::iptables_install (
     }
 
     if $facts['os']['name'].downcase() == 'ubuntu' and $facts['os']['release']['major'] >= '20' {
-      ensure_packages(['iptables-persistent'], {
+      stdlib::ensure_packages(['iptables-persistent'], {
           ensure => installed,
       })
     }
@@ -73,7 +73,7 @@ class cis_security_hardening::rules::iptables_install (
     case $facts['os']['name'].downcase() {
       'redhat', 'centos', 'almalinux', 'rocky': {
         if !defined(Package['nftables']) {
-          ensure_packages(['nftables'], {
+          stdlib::ensure_packages(['nftables'], {
               ensure => purged,
           })
         }
@@ -84,7 +84,7 @@ class cis_security_hardening::rules::iptables_install (
           })
         }
         if !defined(Package['firewalld']) {
-          ensure_packages(['firewalld'], {
+          stdlib::ensure_packages(['firewalld'], {
               ensure => purged,
           })
         }
@@ -96,12 +96,12 @@ class cis_security_hardening::rules::iptables_install (
         }
       }
       'ubuntu', 'debian': {
-        ensure_packages(['ufw', 'nftables'], {
+        stdlib::ensure_packages(['ufw', 'nftables'], {
             ensure => purged,
         })
       }
       'sles': {
-        ensure_packages(['firewalld', 'nftables'], {
+        stdlib::ensure_packages(['firewalld', 'nftables'], {
             ensure => absent,
         })
       }

--- a/manifests/rules/krb5_server.pp
+++ b/manifests/rules/krb5_server.pp
@@ -32,7 +32,7 @@ class cis_security_hardening::rules::krb5_server (
       default => 'purged',
     }
 
-    ensure_packages(['krb5-server'], {
+    stdlib::ensure_packages(['krb5-server'], {
         ensure => $ensure,
     })
   }

--- a/manifests/rules/krb5_workstation.pp
+++ b/manifests/rules/krb5_workstation.pp
@@ -32,7 +32,7 @@ class cis_security_hardening::rules::krb5_workstation (
       default => 'purged',
     }
 
-    ensure_packages(['krb5-workstation'], {
+    stdlib::ensure_packages(['krb5-workstation'], {
         ensure => $ensure,
     })
   }

--- a/manifests/rules/ldap_client.pp
+++ b/manifests/rules/ldap_client.pp
@@ -33,7 +33,7 @@ class cis_security_hardening::rules::ldap_client (
       default => 'purged'
     }
 
-    ensure_packages($pkg, {
+    stdlib::ensure_packages($pkg, {
         ensure => $ensure,
     })
   }

--- a/manifests/rules/ldapd.pp
+++ b/manifests/rules/ldapd.pp
@@ -23,12 +23,12 @@ class cis_security_hardening::rules::ldapd (
   if $enforce {
     case $facts['os']['name'].downcase() {
       'ubuntu': {
-        ensure_packages(['slapd'], {
+        stdlib::ensure_packages(['slapd'], {
             ensure => purged,
         })
       }
       'sles': {
-        ensure_packages(['openldap2'], {
+        stdlib::ensure_packages(['openldap2'], {
             ensure => absent,
         })
       }

--- a/manifests/rules/mcstrans.pp
+++ b/manifests/rules/mcstrans.pp
@@ -25,7 +25,7 @@ class cis_security_hardening::rules::mcstrans (
       'suse'  => 'absent',
       default => 'purged',
     }
-    ensure_packages(['mcstrans'], {
+    stdlib::ensure_packages(['mcstrans'], {
         ensure => $ensure,
     })
   }

--- a/manifests/rules/net_snmp.pp
+++ b/manifests/rules/net_snmp.pp
@@ -43,7 +43,7 @@ class cis_security_hardening::rules::net_snmp (
       default => 'purged',
     }
 
-    ensure_packages($pkg, {
+    stdlib::ensure_packages($pkg, {
         ensure => $ensure,
     })
   }

--- a/manifests/rules/nfs.pp
+++ b/manifests/rules/nfs.pp
@@ -22,7 +22,7 @@ class cis_security_hardening::rules::nfs (
 ) {
   if $enforce {
     if $facts['os']['name'].downcase() == 'ubuntu' {
-      ensure_packages(['nfs-kernel-server'], {
+      stdlib::ensure_packages(['nfs-kernel-server'], {
           ensure => purged,
       })
     } else {

--- a/manifests/rules/nfs_utils.pp
+++ b/manifests/rules/nfs_utils.pp
@@ -31,12 +31,12 @@ class cis_security_hardening::rules::nfs_utils (
     if $uninstall {
       case $facts['os']['name'].downcase() {
         'sles': {
-          ensure_packages(['nfs-utils', 'nfs-kernel-server'], {
+          stdlib::ensure_packages(['nfs-utils', 'nfs-kernel-server'], {
               ensure => absent,
           })
         }
         'rocky', 'almalinux': {
-          ensure_packages(['nfs-utils'], {
+          stdlib::ensure_packages(['nfs-utils'], {
               ensure => absent,
           })
         }
@@ -45,7 +45,7 @@ class cis_security_hardening::rules::nfs_utils (
               ensure => stopped,
               enable => false,
           })
-          ensure_packages(['nfs-utils'], {
+          stdlib::ensure_packages(['nfs-utils'], {
               ensure => absent,
           })
         }

--- a/manifests/rules/nftables_install.pp
+++ b/manifests/rules/nftables_install.pp
@@ -63,7 +63,7 @@ class cis_security_hardening::rules::nftables_install (
       default => 'purged',
     }
 
-    ensure_packages($pkgs_remove, {
+    stdlib::ensure_packages($pkgs_remove, {
         ensure => $ensure,
     })
 
@@ -92,7 +92,7 @@ class cis_security_hardening::rules::nftables_install (
     }
 
     if $facts['os']['name'].downcase() == 'ubuntu' {
-      ensure_packages(['ufw'], {
+      stdlib::ensure_packages(['ufw'], {
           ensure => $ensure,
       })
     }

--- a/manifests/rules/nftables_table.pp
+++ b/manifests/rules/nftables_table.pp
@@ -30,7 +30,7 @@ class cis_security_hardening::rules::nftables_table (
 
     if(!($nftables_default_table in $tables)) {
       if(!defined(Package['nftables'])) {
-        ensure_packages(['nftables'], {
+        stdlib::ensure_packages(['nftables'], {
             ensure => installed,
             before => Exec["create nft table ${nftables_default_table}"],
         })

--- a/manifests/rules/nis.pp
+++ b/manifests/rules/nis.pp
@@ -26,12 +26,12 @@ class cis_security_hardening::rules::nis (
   if $enforce {
     case $facts['os']['name'].downcase() {
       'ubuntu': {
-        ensure_packages(['nis'], {
+        stdlib::ensure_packages(['nis'], {
             ensure => purged,
         })
       }
       'sles':{
-        ensure_packages(['ypserv'], {
+        stdlib::ensure_packages(['ypserv'], {
             ensure => absent,
         })
       }

--- a/manifests/rules/nis_client.pp
+++ b/manifests/rules/nis_client.pp
@@ -38,7 +38,7 @@ class cis_security_hardening::rules::nis_client (
       default => 'purged',
     }
 
-    ensure_packages($pkg, {
+    stdlib::ensure_packages($pkg, {
         ensure => $ensure,
     })
   }

--- a/manifests/rules/ntp_package.pp
+++ b/manifests/rules/ntp_package.pp
@@ -20,7 +20,7 @@ class cis_security_hardening::rules::ntp_package (
   Enum['ntp', 'chrony'] $pkg = 'ntp',
 ) {
   if $enforce {
-    ensure_packages($pkg, {
+    stdlib::ensure_packages($pkg, {
         ensure => installed,
     })
   }

--- a/manifests/rules/ntpd.pp
+++ b/manifests/rules/ntpd.pp
@@ -85,7 +85,7 @@ class cis_security_hardening::rules::ntpd (
     }
 
     if $facts['os']['family'].downcase() == 'debian' {
-      ensure_packages(['chrony'], {
+      stdlib::ensure_packages(['chrony'], {
           ensure => purged,
       })
       ensure_resource('service', 'systemd-timesyncd', {

--- a/manifests/rules/opensc_pkcs11.pp
+++ b/manifests/rules/opensc_pkcs11.pp
@@ -29,7 +29,7 @@ class cis_security_hardening::rules::opensc_pkcs11 (
       default  => ['opensc-pkcs11'],
     }
 
-    ensure_packages($pkgs, {
+    stdlib::ensure_packages($pkgs, {
         ensure => present,
     })
   }

--- a/manifests/rules/openssl_pkcs11.pp
+++ b/manifests/rules/openssl_pkcs11.pp
@@ -31,7 +31,7 @@ class cis_security_hardening::rules::openssl_pkcs11 (
   Boolean $enforce = false
 ) {
   if $enforce {
-    ensure_packages(['openssl-pkcs11'], {
+    stdlib::ensure_packages(['openssl-pkcs11'], {
         ensure => installed,
     })
   }

--- a/manifests/rules/pam_libpwquality.pp
+++ b/manifests/rules/pam_libpwquality.pp
@@ -20,7 +20,7 @@ class cis_security_hardening::rules::pam_libpwquality (
   Boolean $enforce = false,
 ) {
   if $enforce {
-    ensure_packages(['libpwquality'], {
+    stdlib::ensure_packages(['libpwquality'], {
         ensure => installed,
     })
   }

--- a/manifests/rules/pam_mfa_redhat.pp
+++ b/manifests/rules/pam_mfa_redhat.pp
@@ -27,7 +27,7 @@ class cis_security_hardening::rules::pam_mfa_redhat (
   Boolean $enforce = false,
 ) {
   if $enforce {
-    ensure_packages(['dconf'], {
+    stdlib::ensure_packages(['dconf'], {
         ensure => installed,
     })
 

--- a/manifests/rules/pam_pkcs11.pp
+++ b/manifests/rules/pam_pkcs11.pp
@@ -41,7 +41,7 @@ class cis_security_hardening::rules::pam_pkcs11 (
       'redhat' => ['esc', 'pam_pkcs11'],
       default  => ['libpam-pkcs11'],
     }
-    ensure_packages($pkgs, {
+    stdlib::ensure_packages($pkgs, {
         ensure => present,
     })
   }

--- a/manifests/rules/pam_pw_requirements.pp
+++ b/manifests/rules/pam_pw_requirements.pp
@@ -252,7 +252,7 @@ class cis_security_hardening::rules::pam_pw_requirements (
             ensure => installed,
           }
         }
-        ensure_packages(['libpam-pwquality'], {
+        stdlib::ensure_packages(['libpam-pwquality'], {
             ensure => installed,
             notify => Exec['update-pam-config'],
         })

--- a/manifests/rules/policycoreutils.pp
+++ b/manifests/rules/policycoreutils.pp
@@ -28,7 +28,7 @@ class cis_security_hardening::rules::policycoreutils (
   Boolean $enforce = false,
 ) {
   if $enforce {
-    ensure_packages(['policycoreutils'], {
+    stdlib::ensure_packages(['policycoreutils'], {
         ensure => installed,
     })
   }

--- a/manifests/rules/rng_tools.pp
+++ b/manifests/rules/rng_tools.pp
@@ -25,7 +25,7 @@ class cis_security_hardening::rules::rng_tools (
   Boolean $enforce = false,
 ) {
   if $enforce {
-    ensure_packages(['rng-tools'], {
+    stdlib::ensure_packages(['rng-tools'], {
         ensure => installed,
     })
   }

--- a/manifests/rules/rpcbind.pp
+++ b/manifests/rules/rpcbind.pp
@@ -42,7 +42,7 @@ class cis_security_hardening::rules::rpcbind (
     if $uninstall {
       case $facts['os']['name'].downcase() {
         'ubuntu': {
-          ensure_packages(['rpcbind'], {
+          stdlib::ensure_packages(['rpcbind'], {
               ensure => purged,
           })
         }
@@ -55,12 +55,12 @@ class cis_security_hardening::rules::rpcbind (
               ensure => stopped,
               enable => false,
           })
-          ensure_packages(['rpcbind'], {
+          stdlib::ensure_packages(['rpcbind'], {
               ensure => absent,
           })
         }
         'rocky', 'almalinux': {
-          ensure_packages(['rpcbind'], {
+          stdlib::ensure_packages(['rpcbind'], {
               ensure => absent,
           })
 
@@ -74,7 +74,7 @@ class cis_security_hardening::rules::rpcbind (
               ensure => 'stopped',
               enable => false,
           })
-          ensure_packages(['rpcbind'], {
+          stdlib::ensure_packages(['rpcbind'], {
               ensure => absent,
           })
         }

--- a/manifests/rules/rsh_client.pp
+++ b/manifests/rules/rsh_client.pp
@@ -32,7 +32,7 @@ class cis_security_hardening::rules::rsh_client (
         'suse'  => 'absent',
         default => 'purged',
       }
-      ensure_packages($pkg, {
+      stdlib::ensure_packages($pkg, {
           ensure => $ensure,
       })
     }

--- a/manifests/rules/rsh_server.pp
+++ b/manifests/rules/rsh_server.pp
@@ -40,7 +40,7 @@ class cis_security_hardening::rules::rsh_server (
     }
 
     unless empty($pkgs) {
-      ensure_packages($pkgs, {
+      stdlib::ensure_packages($pkgs, {
           ensure => $ensure,
       })
     }

--- a/manifests/rules/rsyncd.pp
+++ b/manifests/rules/rsyncd.pp
@@ -21,7 +21,7 @@ class cis_security_hardening::rules::rsyncd (
   if $enforce {
     case $facts['os']['family'].downcase() {
       'debian': {
-        ensure_packages(['rsync'], {
+        stdlib::ensure_packages(['rsync'], {
             ensure => purged,
         })
 
@@ -37,7 +37,7 @@ class cis_security_hardening::rules::rsyncd (
         }
       }
       'suse': {
-        ensure_packages(['rsync'], {
+        stdlib::ensure_packages(['rsync'], {
             ensure => absent,
         })
       }

--- a/manifests/rules/rsyslog_installed.pp
+++ b/manifests/rules/rsyslog_installed.pp
@@ -23,7 +23,7 @@ class cis_security_hardening::rules::rsyslog_installed (
   Boolean $enforce = false,
 ) {
   if $enforce {
-    ensure_packages(['rsyslog'], {
+    stdlib::ensure_packages(['rsyslog'], {
         ensure => installed,
     })
   }

--- a/manifests/rules/samba.pp
+++ b/manifests/rules/samba.pp
@@ -30,7 +30,7 @@ class cis_security_hardening::rules::samba (
         default => 'purged',
       }
 
-      ensure_packages(['samba'], {
+      stdlib::ensure_packages(['samba'], {
           ensure => $ensure,
       })
     } else {

--- a/manifests/rules/selinux.pp
+++ b/manifests/rules/selinux.pp
@@ -20,7 +20,7 @@ class cis_security_hardening::rules::selinux (
   Boolean $enforce = false,
 ) {
   if $enforce {
-    ensure_packages(['libselinux'], {
+    stdlib::ensure_packages(['libselinux'], {
         ensure => present,
     })
   }

--- a/manifests/rules/sendmail.pp
+++ b/manifests/rules/sendmail.pp
@@ -35,7 +35,7 @@ class cis_security_hardening::rules::sendmail (
       'suse'  => 'absent',
       default => 'purged',
     }
-    ensure_packages(['sendmail'], {
+    stdlib::ensure_packages(['sendmail'], {
         ensure => $ensure,
     })
   }

--- a/manifests/rules/setroubleshoot.pp
+++ b/manifests/rules/setroubleshoot.pp
@@ -25,7 +25,7 @@ class cis_security_hardening::rules::setroubleshoot (
       'suse'  => 'absent',
       default => 'purged',
     }
-    ensure_packages(['setroubleshoot'], {
+    stdlib::ensure_packages(['setroubleshoot'], {
         ensure => $ensure,
     })
   }

--- a/manifests/rules/squid.pp
+++ b/manifests/rules/squid.pp
@@ -26,7 +26,7 @@ class cis_security_hardening::rules::squid (
         'suse'  => 'absent',
         default => 'purged',
       }
-      ensure_packages(['squid'], {
+      stdlib::ensure_packages(['squid'], {
           ensure => $ensure,
       })
     } else {

--- a/manifests/rules/sshd_install.pp
+++ b/manifests/rules/sshd_install.pp
@@ -36,7 +36,7 @@ class cis_security_hardening::rules::sshd_install (
       'redhat' => ['openssh-server'],
       default  => ['ssh']
     }
-    ensure_packages($pkgs, {
+    stdlib::ensure_packages($pkgs, {
         ensure => present,
     })
 

--- a/manifests/rules/sudo_installed.pp
+++ b/manifests/rules/sudo_installed.pp
@@ -35,7 +35,7 @@ class cis_security_hardening::rules::sudo_installed (
   Array $sudo_pkgs = ['sudo']
 ) {
   if $enforce {
-    ensure_packages($sudo_pkgs, {
+    stdlib::ensure_packages($sudo_pkgs, {
         ensure => installed,
     })
   }

--- a/manifests/rules/systemd_timesyncd.pp
+++ b/manifests/rules/systemd_timesyncd.pp
@@ -56,7 +56,7 @@ class cis_security_hardening::rules::systemd_timesyncd (
         default => 'purged',
       }
 
-      ensure_packages(['ntp', 'chrony'], {
+      stdlib::ensure_packages(['ntp', 'chrony'], {
           ensure => $ensure,
       })
 

--- a/manifests/rules/talk_client.pp
+++ b/manifests/rules/talk_client.pp
@@ -26,7 +26,7 @@ class cis_security_hardening::rules::talk_client (
       default => 'purged',
     }
 
-    ensure_packages(['talk'], {
+    stdlib::ensure_packages(['talk'], {
         ensure => $ensure,
     })
   }

--- a/manifests/rules/telnet_client.pp
+++ b/manifests/rules/telnet_client.pp
@@ -24,12 +24,12 @@ class cis_security_hardening::rules::telnet_client (
   if $enforce {
     case $facts['os']['family'].downcase() {
       'suse': {
-        ensure_packages(['telnet'], {
+        stdlib::ensure_packages(['telnet'], {
             ensure => 'absent',
         })
       }
       default: {
-        ensure_packages(['telnet'], {
+        stdlib::ensure_packages(['telnet'], {
             ensure => 'purged',
         })
       }

--- a/manifests/rules/telnet_server.pp
+++ b/manifests/rules/telnet_server.pp
@@ -39,7 +39,7 @@ class cis_security_hardening::rules::telnet_server (
           enable => false,
       })
     }
-    ensure_packages($pkgs, {
+    stdlib::ensure_packages($pkgs, {
         ensure => $ensure,
     })
   }

--- a/manifests/rules/tftp_client.pp
+++ b/manifests/rules/tftp_client.pp
@@ -21,7 +21,7 @@ class cis_security_hardening::rules::tftp_client (
   Boolean $enforce = false,
 ) {
   if $enforce {
-    ensure_packages(['tftp'], {
+    stdlib::ensure_packages(['tftp'], {
         ensure => absent,
     })
   }

--- a/manifests/rules/tftp_server.pp
+++ b/manifests/rules/tftp_server.pp
@@ -26,7 +26,7 @@ class cis_security_hardening::rules::tftp_server (
       default => 'purged',
     }
 
-    ensure_packages(['tftp-server'], {
+    stdlib::ensure_packages(['tftp-server'], {
         ensure => $ensure,
     })
   }

--- a/manifests/rules/tmux_package.pp
+++ b/manifests/rules/tmux_package.pp
@@ -28,7 +28,7 @@ class cis_security_hardening::rules::tmux_package (
   Boolean $enforce = false,
 ) {
   if $enforce {
-    ensure_packages(['tmux'], {
+    stdlib::ensure_packages(['tmux'], {
         ensure => installed,
     })
   }

--- a/manifests/rules/tuned.pp
+++ b/manifests/rules/tuned.pp
@@ -33,7 +33,7 @@ class cis_security_hardening::rules::tuned (
       default => 'purged',
     }
 
-    ensure_packages(['tuned'], {
+    stdlib::ensure_packages(['tuned'], {
         ensure => $ensure,
     })
   }

--- a/manifests/rules/ufw_install.pp
+++ b/manifests/rules/ufw_install.pp
@@ -29,7 +29,7 @@ class cis_security_hardening::rules::ufw_install (
   Boolean $enforce = false,
 ) {
   if $enforce {
-    ensure_packages(['ufw'], {
+    stdlib::ensure_packages(['ufw'], {
         ensure => installed,
     })
 
@@ -38,7 +38,7 @@ class cis_security_hardening::rules::ufw_install (
       default => 'purged',
     }
 
-    ensure_packages(['iptables-persistent'], {
+    stdlib::ensure_packages(['iptables-persistent'], {
         ensure => $ensure,
     })
   }

--- a/manifests/rules/usbguard_package.pp
+++ b/manifests/rules/usbguard_package.pp
@@ -29,7 +29,7 @@ class cis_security_hardening::rules::usbguard_package (
   Boolean $enforce = false,
 ) {
   if $enforce {
-    ensure_packages(['usbguard'], {
+    stdlib::ensure_packages(['usbguard'], {
         ensure => installed,
     })
   }

--- a/manifests/rules/vlock.pp
+++ b/manifests/rules/vlock.pp
@@ -26,7 +26,7 @@ class cis_security_hardening::rules::vlock (
   Boolean $enforce = false,
 ) {
   if $enforce {
-    ensure_packages(['vlock'], {
+    stdlib::ensure_packages(['vlock'], {
         ensure => present,
     })
   }

--- a/manifests/rules/vsftp.pp
+++ b/manifests/rules/vsftp.pp
@@ -28,7 +28,7 @@ class cis_security_hardening::rules::vsftp (
         default => 'purged',
       }
 
-      ensure_packages(['vsftpd'], {
+      stdlib::ensure_packages(['vsftpd'], {
           ensure => $ensure,
       })
     } else {

--- a/manifests/rules/x11_installed.pp
+++ b/manifests/rules/x11_installed.pp
@@ -32,7 +32,7 @@ class cis_security_hardening::rules::x11_installed (
           'suse'  => 'absent',
           default => 'purged',
         }
-        ensure_packages([$pkg], {
+        stdlib::ensure_packages([$pkg], {
             ensure => $ensure,
         })
       }

--- a/manifests/rules/xinetd.pp
+++ b/manifests/rules/xinetd.pp
@@ -26,7 +26,7 @@ class cis_security_hardening::rules::xinetd (
       default => 'purged',
     }
 
-    ensure_packages(['xinetd'], {
+    stdlib::ensure_packages(['xinetd'], {
         ensure => $ensure,
     })
   }


### PR DESCRIPTION
`ensure_packages` is deprecated, hence using namespaced function.

Fixes warning:

```
This function is deprecated, please use stdlib::ensure_packages instead. at [....]
```
