### PR TITLE
Add /sbin and /usr/sbin to path for dpkg-reconfigure

### DIFF
--- a/manifests/rules/gnome_gdm.pp
+++ b/manifests/rules/gnome_gdm.pp
@@ -106,7 +106,7 @@ class cis_security_hardening::rules::gnome_gdm (
           }
         }
         exec { 'dpkg-gdm-reconfigure':
-          path        => ['/bin', '/usr/bin'],
+          path        => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
           command     => 'dpkg-reconfigure gdm3',
           refreshonly => true,
         }
@@ -122,7 +122,7 @@ class cis_security_hardening::rules::gnome_gdm (
         }
 
         exec { 'dpkg-gdm-reconfigure':
-          path        => ['/bin', '/usr/bin'],
+          path        => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
           command     => 'dpkg-reconfigure gdm3',
           refreshonly => true,
         }

--- a/spec/classes/rules/gnome_gdm_spec.rb
+++ b/spec/classes/rules/gnome_gdm_spec.rb
@@ -146,7 +146,7 @@ All activity may be monitored and reported.\'\ndisable-user-list=true\n",
 
               is_expected.to contain_exec('dpkg-gdm-reconfigure')
                 .with(
-                  'path'        => ['/bin', '/usr/bin'],
+                  'path'        => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
                   'command'     => 'dpkg-reconfigure gdm3',
                   'refreshonly' => true,
                 )


### PR DESCRIPTION
Fix running dpkg-reconfigure by adding /sbin and /usr/sbin to the path for it