### PR TITLE
Load gdm_screensaver on ubuntu 22.04

### DIFF
--- a/data/cis/cis_Ubuntu_22.04_rules.yaml
+++ b/data/cis/cis_Ubuntu_22.04_rules.yaml
@@ -57,6 +57,7 @@ cis_security_hardening::benchmark::ubuntu::22:
       level1:
         - gnome_gdm
         - gdm_auto_mount
+        - gdm_screensaver
         - xdmcp_config
       level2:
         - gnome_gdm_package


### PR DESCRIPTION
Use the `gdm_screensaver` module on Ubuntu 22.04
