### PR TITLE
allow params to be set for logrotate class

### DIFF
--- a/manifests/rules/logrotate.pp
+++ b/manifests/rules/logrotate.pp
@@ -15,6 +15,8 @@
 #    Use date extension for rotated files.
 # @param compress
 #    Compress rotated files.
+# @param delaycompress
+#    Delay compression of rotated files.
 # @param rotate
 #    Number of rotations to keep.
 # @param rotate_every
@@ -38,7 +40,7 @@ class cis_security_hardening::rules::logrotate (
   Boolean $enforce       = false,
   Boolean $dateext       = true,
   Boolean $compress      = true,
-  Boolean $delaycompress = true,
+  Boolean $delaycompress = false,
   Integer $rotate        = 7,
   String $rotate_every   = 'week',
   Boolean $ifempty       = true,

--- a/spec/classes/rules/logrotate_spec.rb
+++ b/spec/classes/rules/logrotate_spec.rb
@@ -33,7 +33,7 @@ describe 'cis_security_hardening::rules::logrotate' do
                 'config' => {
                   'dateext'       => true,
                   'compress'      => true,
-                  'delaycompress' => true,
+                  'delaycompress' => false,
                   'rotate'        => 7,
                   'rotate_every'  => 'week',
                   'ifempty'       => true,


### PR DESCRIPTION
Adds ability to pass in relevant parameters to puppet-logrotate where they were hardcoded before. In particular, Ubuntu 22.04 needs a su root adm line in logrotate.conf for log rotation to work properly.