### PR TITLE
Remove space from login screen settings on sles

### DIFF
--- a/manifests/rules/gnome_gdm.pp
+++ b/manifests/rules/gnome_gdm.pp
@@ -146,7 +146,7 @@ class cis_security_hardening::rules::gnome_gdm (
           notify  => Exec['dpkg-gdm-reconfigure'],
         }
 
-        file { '/etc/dconf/db/gdm.d/00- login-screen':
+        file { '/etc/dconf/db/gdm.d/00-login-screen':
           ensure  => file,
           content => "[org/gnome/login-screen]\ndisable-user-list=true\n",
           owner   => 'root',

--- a/spec/classes/rules/gnome_gdm_spec.rb
+++ b/spec/classes/rules/gnome_gdm_spec.rb
@@ -183,7 +183,7 @@ All activity may be monitored and reported.\'\ndisable-user-list=true\n",
                 )
                 .that_notifies('Exec[dpkg-gdm-reconfigure]')
 
-              is_expected.to contain_file('/etc/dconf/db/gdm.d/00- login-screen')
+              is_expected.to contain_file('/etc/dconf/db/gdm.d/00-login-screen')
                 .with(
                   'ensure'  => 'file',
                   'content' => "[org/gnome/login-screen]\ndisable-user-list=true\n",
@@ -202,7 +202,7 @@ All activity may be monitored and reported.\'\ndisable-user-list=true\n",
             else
               is_expected.not_to contain_file('/etc/dconf/profile/gdm')
               is_expected.not_to contain_file('/etc/dconf/db/gdm.d/01-banner-message')
-              is_expected.not_to contain_file('/etc/dconf/db/gdm.d/00- login-screen')
+              is_expected.not_to contain_file('/etc/dconf/db/gdm.d/00-login-screen')
               is_expected.not_to contain_exec('dpkg-gdm-reconfigure')
             end
           end


### PR DESCRIPTION
Remove the space from the filename for login screen settings on SLES