### PR TITLE
Manage world writeable cron file

### DIFF
--- a/manifests/rules/aide_regular_checks.pp
+++ b/manifests/rules/aide_regular_checks.pp
@@ -86,7 +86,7 @@ class cis_security_hardening::rules::aide_regular_checks (
     } else {
       if ! empty($content) {
         file { '/etc/cron.d/aide.cron':
-          ensure  => absent,
+          ensure => absent,
         }
         file { '/etc/cron.d/aide':
           ensure  => file,

--- a/manifests/sticky_world_writable_cron.pp
+++ b/manifests/sticky_world_writable_cron.pp
@@ -49,4 +49,7 @@ class cis_security_hardening::sticky_world_writable_cron (
     group   => 'root',
     mode    => '0644',
   }
+  file { $filename:
+    ensure => stdlib::ensure($ensure, file),
+  }
 }

--- a/spec/classes/sticky_world_writabe_cron_spec.rb
+++ b/spec/classes/sticky_world_writabe_cron_spec.rb
@@ -39,6 +39,11 @@ describe 'cis_security_hardening::sticky_world_writable_cron' do
               'group'   => 'root',
               'mode'    => '0644',
             )
+
+          is_expected.to contain_file('/usr/share/cis_security_hardening/data/world-writable-files.txt')
+            .with(
+              'ensure' => 'file',
+            )
         end
       end
 
@@ -74,6 +79,11 @@ describe 'cis_security_hardening::sticky_world_writable_cron' do
               'owner'   => 'root',
               'group'   => 'root',
               'mode'    => '0644',
+            )
+
+          is_expected.to contain_file('/usr/share/cis_security_hardening/data/world-writable-files.txt')
+            .with(
+              'ensure' => 'absent',
             )
         end
       end


### PR DESCRIPTION
Manage the world writeable cron output file, so that when disabling the cron it also cleans up the file and facts.

