### PR TITLE
Use audit for pam_faillock

### DIFF
--- a/files/pam_lockout/debian/common-auth
+++ b/files/pam_lockout/debian/common-auth
@@ -1,6 +1,6 @@
-auth    required                        pam_faillock.so preauth debug
+auth    required                        pam_faillock.so preauth audit
 auth    [success=1 default=ignore]      pam_unix.so nullok
-auth    [default=die]                   pam_faillock.so authfail debug
-auth    [success=1]                     pam_faillock.so authsucc debug
+auth    [default=die]                   pam_faillock.so authfail audit
+auth    [success=1]                     pam_faillock.so authsucc audit
 auth    requisite                       pam_deny.so
 auth    required                        pam_permit.so

--- a/files/pam_lockout/ubuntu/common-auth
+++ b/files/pam_lockout/ubuntu/common-auth
@@ -1,6 +1,6 @@
-auth    required                        pam_faillock.so preauth debug
+auth    required                        pam_faillock.so preauth audit
 auth    [success=1 default=ignore]      pam_unix.so nullok
-auth    [default=die]                   pam_faillock.so authfail debug
-auth    [success=1]                     pam_faillock.so authsucc debug
+auth    [default=die]                   pam_faillock.so authfail audit
+auth    [success=1]                     pam_faillock.so authsucc audit
 auth    requisite                       pam_deny.so
 auth    required                        pam_permit.so


### PR DESCRIPTION
Use audit instead of debug (which is invalid) for pam_faillock.

