### PR TITLE
Have auditd_init require the auditd package

### DIFF
--- a/manifests/rules/auditd_init.pp
+++ b/manifests/rules/auditd_init.pp
@@ -29,6 +29,8 @@ class cis_security_hardening::rules::auditd_init (
   Boolean $auto_reboot             = true,
 ) {
   if $enforce {
+    require cis_security_hardening::rules::auditd_package
+
     $notify = $auto_reboot ? {
       true  => [Exec['reload auditd rules'], Class['cis_security_hardening::reboot']],
       false => Exec['reload auditd rules'],


### PR DESCRIPTION
Have the `auditd_init` class require `auditd_package` class so that the package gets installed first before we try to change the configs, etc.
