### PR TITLE
Make cron.allow world readable

### DIFF
--- a/manifests/rules/cron_restrict.pp
+++ b/manifests/rules/cron_restrict.pp
@@ -30,7 +30,7 @@ class cis_security_hardening::rules::cron_restrict (
       ensure => file,
       owner  => 'root',
       group  => 'root',
-      mode   => '0600',
+      mode   => '0644',
     }
 
     file { '/etc/cron.deny':

--- a/spec/classes/rules/cron_restrict_spec.rb
+++ b/spec/classes/rules/cron_restrict_spec.rb
@@ -24,7 +24,7 @@ describe 'cis_security_hardening::rules::cron_restrict' do
                 'ensure' => 'file',
                 'owner'  => 'root',
                 'group'  => 'root',
-                'mode'   => '0600',
+                'mode'   => '0644',
               )
 
             is_expected.to contain_file('/etc/cron.deny')


### PR DESCRIPTION
Make `/etc/cron.allow` world-readable, so that you can still use it to restrict who can schedule user crons.

