### PR TITLE
Set nologin for ubuntu and sles

### DIFF
--- a/manifests/rules/shell_nologin.pp
+++ b/manifests/rules/shell_nologin.pp
@@ -35,6 +35,9 @@ class cis_security_hardening::rules::shell_nologin (
           default => '/sbin/nologin',
         }
       }
+      'ubuntu', 'sles': {
+        $nologin = '/usr/sbin/nologin'
+      }
       default: {
         $nologin = '/sbin/nologin'
       }

--- a/spec/classes/rules/shell_nologin_spec.rb
+++ b/spec/classes/rules/shell_nologin_spec.rb
@@ -27,7 +27,9 @@ describe 'cis_security_hardening::rules::shell_nologin' do
           is_expected.to compile
 
           if enforce
-            if os_facts[:os]['name'].casecmp('debian').zero? && os_facts[:os]['release']['major'] == '12'
+            if (os_facts[:os]['name'].casecmp('debian').zero? && os_facts[:os]['release']['major'] == '12') ||
+               os_facts[:os]['name'].casecmp('ubuntu').zero? ||
+               os_facts[:os]['name'].casecmp('sles').zero?
               is_expected.to contain_exec('nologin test1')
                 .with(
                 'command' => 'usermod -s /usr/sbin/nologin test1',


### PR DESCRIPTION
For Ubuntu and SLES, nologin should be `/usr/sbin/nologin`

