### PR TITLE
Use tabs for sudo defaults

### DIFF
--- a/manifests/rules/sudo_log.pp
+++ b/manifests/rules/sudo_log.pp
@@ -23,7 +23,7 @@ class cis_security_hardening::rules::sudo_log (
       path               => '/etc/sudoers',
       match              => 'Defaults.*logfile\s*=',
       append_on_no_match => true,
-      line               => 'Defaults logfile=/var/log/sudo.log',
+      line               => "Defaults\tlogfile=\"/var/log/sudo.log\"",
       after              => '# Defaults specification',
     }
   }

--- a/manifests/rules/sudo_timeout.pp
+++ b/manifests/rules/sudo_timeout.pp
@@ -26,7 +26,7 @@ class cis_security_hardening::rules::sudo_timeout (
     file_line { 'set sudo timeout':
       path               => '/etc/sudoers',
       match              => '^Defaults\s+timestamp_timeout=',
-      line               => "Defaults timestamp_timeout=${timeout}",
+      line               => "Defaults\ttimestamp_timeout=${timeout}",
       append_on_no_match => true,
     }
   }

--- a/manifests/rules/sudo_use_pty.pp
+++ b/manifests/rules/sudo_use_pty.pp
@@ -24,7 +24,7 @@ class cis_security_hardening::rules::sudo_use_pty (
       path               => '/etc/sudoers',
       match              => 'Defaults.*use_pty',
       append_on_no_match => true,
-      line               => 'Defaults use_pty',
+      line               => "Defaults\tuse_pty",
       after              => '# Defaults specification',
     }
   }

--- a/spec/classes/rules/sudo_log_spec.rb
+++ b/spec/classes/rules/sudo_log_spec.rb
@@ -24,7 +24,7 @@ describe 'cis_security_hardening::rules::sudo_log' do
                 'path'               => '/etc/sudoers',
                 'match'              => 'Defaults.*logfile\s*=',
                 'append_on_no_match' => true,
-                'line'               => 'Defaults logfile=/var/log/sudo.log',
+                'line'               => "Defaults\tlogfile=\"/var/log/sudo.log\"",
                 'after'              => '# Defaults specification',
               )
           else

--- a/spec/classes/rules/sudo_timeout_spec.rb
+++ b/spec/classes/rules/sudo_timeout_spec.rb
@@ -24,7 +24,7 @@ describe 'cis_security_hardening::rules::sudo_timeout' do
               .with(
                 'path'               => '/etc/sudoers',
                 'match'              => '^Defaults\s+timestamp_timeout=',
-                'line'               => 'Defaults timestamp_timeout=10',
+                'line'               => "Defaults\ttimestamp_timeout=10",
                 'append_on_no_match' => true,
               )
           else

--- a/spec/classes/rules/sudo_use_pty_spec.rb
+++ b/spec/classes/rules/sudo_use_pty_spec.rb
@@ -24,7 +24,7 @@ describe 'cis_security_hardening::rules::sudo_use_pty' do
                 'path'               => '/etc/sudoers',
                 'match'              => 'Defaults.*use_pty',
                 'append_on_no_match' => true,
-                'line'               => 'Defaults use_pty',
+                'line'               => "Defaults\tuse_pty",
                 'after'              => '# Defaults specification',
               )
           else


### PR DESCRIPTION
Use tabs for sudo default spacing to be compatible with e.g. https://github.com/saz/puppet-sudo