### PR TITLE
Fix the duplicate `/boot/efi` entries in `/etc/fstab`

### DIFF
--- a/manifests/rules/grub_bootloader_config.pp
+++ b/manifests/rules/grub_bootloader_config.pp
@@ -77,12 +77,12 @@ class cis_security_hardening::rules::grub_bootloader_config (
     if fact('cis_security_hardening.efi') and cis_security_hardening::hash_key($facts['mountpoints'], '/boot/efi') {
       $device = $facts['mountpoints']['/boot/efi']['device']
       $uuid   = $facts['partitions'][$device]['uuid']
-      $line   = "UUID=${uuid}  /boot/efi       vfat    umask=0077,fmask=0077,uid=0,gid=0      0        1"
+      $line   = "/dev/disk/by-uuid/${uuid}  /boot/efi       vfat    umask=0077,fmask=0077,uid=0,gid=0      0        1"
 
       file_line { 'fix /boot/efi':
         ensure             => present,
         path               => '/etc/fstab',
-        match              => "^UUID=${uuid}\\s+/boot/efi\\s+vfat",
+        match              => '^[^#]*\s+/boot/efi\s+',
         line               => $line,
         append_on_no_match => true,
       }

--- a/spec/classes/rules/grub_bootloader_config_spec.rb
+++ b/spec/classes/rules/grub_bootloader_config_spec.rb
@@ -135,8 +135,8 @@ describe 'cis_security_hardening::rules::grub_bootloader_config' do
               with(
                 'ensure'             => 'present',
                 'path'               => '/etc/fstab',
-                'match'              => '^UUID=583bc67c-8dfa-42f2-9022-6d3161d34521\\s+/boot/efi\\s+vfat',
-                'line'               => 'UUID=583bc67c-8dfa-42f2-9022-6d3161d34521  /boot/efi       vfat    umask=0077,fmask=0077,uid=0,gid=0      0        1',
+                'match'              => '^[^#]*\s+/boot/efi\s+',
+                'line'               => '/dev/disk/by-uuid/583bc67c-8dfa-42f2-9022-6d3161d34521  /boot/efi       vfat    umask=0077,fmask=0077,uid=0,gid=0      0        1',
                 'append_on_no_match' => true
               )
 


### PR DESCRIPTION
#### Pull Request (PR) description

Fix the duplicate `/boot/efi` entries in `/etc/fstab` by matching with `/boot/efi`
Use the `/dev/disk/by-uuid/<uuid>` format when adding the entry.

#### This Pull Request (PR) fixes the following issues

