### PR TITLE
Add `disable_bluetooth` for Ubuntu 18 and 22

### DIFF
--- a/data/cis/cis_Ubuntu_18.04_params.yaml
+++ b/data/cis/cis_Ubuntu_18.04_params.yaml
@@ -126,6 +126,7 @@ cis_security_hardening::rules::ldap_client::enforce: true
 
 cis_security_hardening::rules::disable_ipv6::enforce: true
 cis_security_hardening::rules::disable_wireless::enforce: true
+cis_security_hardening::rules::disable_bluetooth::enforce: true
 
 cis_security_hardening::rules::disable_ip_forwarding::enforce: true
 cis_security_hardening::rules::disable_packet_redirect::enforce: true

--- a/data/cis/cis_Ubuntu_18.04_rules.yaml
+++ b/data/cis/cis_Ubuntu_18.04_rules.yaml
@@ -85,6 +85,8 @@ cis_security_hardening::benchmark::ubuntu::v18:
         - telnet_client
         - ldap_client
     unused_network_protocols:
+      level1:
+        - disable_bluetooth
       level2:
         - disable_ipv6
         - disable_wireless

--- a/data/cis/cis_Ubuntu_22.04_params.yaml
+++ b/data/cis/cis_Ubuntu_22.04_params.yaml
@@ -155,6 +155,7 @@ cis_security_hardening::rules::rpcbind::enforce: true
 
 cis_security_hardening::rules::disable_ipv6::enforce: true
 cis_security_hardening::rules::disable_wireless::enforce: true
+cis_security_hardening::rules::disable_bluetooth::enforce: true
 
 cis_security_hardening::rules::disable_ip_forwarding::enforce: true
 cis_security_hardening::rules::disable_packet_redirect::enforce: true

--- a/data/cis/cis_Ubuntu_22.04_rules.yaml
+++ b/data/cis/cis_Ubuntu_22.04_rules.yaml
@@ -93,6 +93,8 @@ cis_security_hardening::benchmark::ubuntu::v22:
         - ldap_client
         - rpcbind
     unused_network_protocols:
+      level1:
+        - disable_bluetooth
       level2:
         - disable_ipv6
         - disable_wireless


### PR DESCRIPTION
#### Pull Request (PR) description

Add `disable_bluetooth` for Ubuntu 18.04 and 22.04.

#### This Pull Request (PR) fixes the following issues

