### PR TITLE
Allow ufw_open_ports and ufw_outbound to accept integers and port ranges

### DIFF
--- a/manifests/rules/ufw_open_ports.pp
+++ b/manifests/rules/ufw_open_ports.pp
@@ -43,10 +43,10 @@ class cis_security_hardening::rules::ufw_open_ports (
       }
 
       if cis_security_hardening::hash_key($data, 'port') {
-        unless $data['port'] =~ /^\d+$/ {
+        unless $data['port'] =~ /^\d+(:\d+)?$/ {
           fail("Illegal port: ${data['port']}")
         }
-        $port = $data['port']
+        $port = String($data['port'])
       } else {
         $port = ''
       }

--- a/manifests/rules/ufw_open_ports.pp
+++ b/manifests/rules/ufw_open_ports.pp
@@ -43,10 +43,10 @@ class cis_security_hardening::rules::ufw_open_ports (
       }
 
       if cis_security_hardening::hash_key($data, 'port') {
-        unless $data['port'] =~ /^\d+(:\d+)?$/ {
+        $port = String($data['port'])
+        unless $port =~ /^\d+(:\d+)?$/ {
           fail("Illegal port: ${data['port']}")
         }
-        $port = String($data['port'])
       } else {
         $port = ''
       }

--- a/manifests/rules/ufw_outbound.pp
+++ b/manifests/rules/ufw_outbound.pp
@@ -44,10 +44,10 @@ class cis_security_hardening::rules::ufw_outbound (
       }
 
       if cis_security_hardening::hash_key($data, 'port') {
-        unless $data['port'] =~ /^\d+$/ {
+        unless $data['port'] =~ /^\d+(:\d+)?$/ {
           fail("Illegal port: ${data['port']}")
         }
-        $port = $data['port']
+        $port = String($data['port'])
       } else {
         $port = ''
       }

--- a/manifests/rules/ufw_outbound.pp
+++ b/manifests/rules/ufw_outbound.pp
@@ -44,10 +44,10 @@ class cis_security_hardening::rules::ufw_outbound (
       }
 
       if cis_security_hardening::hash_key($data, 'port') {
-        unless $data['port'] =~ /^\d+(:\d+)?$/ {
+        $port = String($data['port'])
+        unless $port =~ /^\d+(:\d+)?$/ {
           fail("Illegal port: ${data['port']}")
         }
-        $port = String($data['port'])
       } else {
         $port = ''
       }

--- a/spec/classes/rules/ufw_open_ports_spec.rb
+++ b/spec/classes/rules/ufw_open_ports_spec.rb
@@ -55,6 +55,22 @@ describe 'cis_security_hardening::rules::ufw_open_ports' do
                 'from' => '192.168.1.0/24',
                 'to' => 'any',
               },
+              'allow speedify data integer port' => {
+                'queue' => 'in',
+                'port' => 8443,
+                'proto' => 'tcp',
+                'action' => 'allow',
+                'from' => 'any',
+                'to' => 'any',
+              },
+              'allow speedify data range' => {
+                'queue' => 'in',
+                'port' => '37000:38000',
+                'proto' => 'tcp',
+                'action' => 'allow',
+                'from' => 'any',
+                'to' => 'any',
+              },
             },
           }
         end
@@ -80,6 +96,18 @@ describe 'cis_security_hardening::rules::ufw_open_ports' do
                 'command' => 'ufw allow proto tcp from 192.168.1.0/24 to any port 22',
                 'path'    => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
                 'onlyif'  => 'test -z "$(ufw status verbose | grep -E -i \'^22/tcp.*ALLOW in.*192.168.1.0/24\')"'
+              )
+            is_expected.to contain_exec('allow speedify data integer port').
+              with(
+                'command' => 'ufw allow proto tcp from any to any port 8443',
+                'path'    => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
+                'onlyif'  => 'test -z "$(ufw status verbose | grep -E -i \'^8443/tcp.*ALLOW in\')"'
+              )
+            is_expected.to contain_exec('allow speedify data range').
+              with(
+                'command' => 'ufw allow proto tcp from any to any port 37000:38000',
+                'path'    => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
+                'onlyif'  => 'test -z "$(ufw status verbose | grep -E -i \'^37000:38000/tcp.*ALLOW in\')"'
               )
           else
             is_expected.not_to contain_exec('allow ssh')

--- a/spec/classes/rules/ufw_outbound_spec.rb
+++ b/spec/classes/rules/ufw_outbound_spec.rb
@@ -38,6 +38,20 @@ describe 'cis_security_hardening::rules::ufw_outbound' do
                 'proto' => 'tcp',
                 'action' => 'allow',
               },
+              'allow dns with integer port' => {
+                'queue' => 'out',
+                'to' => 'any',
+                'port' => 53,
+                'proto' => 'udp',
+                'action' => 'allow',
+              },
+              'allow port range' => {
+                'queue' => 'out',
+                'to' => 'any',
+                'port' => '37000:38000',
+                'proto' => 'tcp',
+                'action' => 'allow',
+              },
             },
           }
         end
@@ -57,6 +71,18 @@ describe 'cis_security_hardening::rules::ufw_outbound' do
                 'command' => 'ufw allow out to any port 80',
                 'path'    => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
                 'onlyif'  => 'test -z "$(ufw status verbose | grep -E -i \'^80.*ALLOW out\')"'
+              )
+            is_expected.to contain_exec('allow dns with integer port').
+              with(
+                'command' => 'ufw allow out to any port 53',
+                'path'    => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
+                'onlyif'  => 'test -z "$(ufw status verbose | grep -E -i \'^53.*ALLOW out\')"'
+              )
+            is_expected.to contain_exec('allow port range').
+              with(
+                'command' => 'ufw allow out to any port 37000:38000',
+                'path'    => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
+                'onlyif'  => 'test -z "$(ufw status verbose | grep -E -i \'^37000:38000.*ALLOW out\')"'
               )
           else
             is_expected.not_to contain_exec('allow DNS outbound')


### PR DESCRIPTION
#### Pull Request (PR) description

Enables the ability to set ufw port ranges. It also allows for the port to be entered as an integer or a string

#### This Pull Request (PR) fixes the following issues

Fixes the issue of only being able to set a specific port and not a range.
