### PR TITLE
fix rsyslog duplicate messages and not restarting after config change

### DIFF
--- a/data/cis/cis_CentOS_8_params.yaml
+++ b/data/cis/cis_CentOS_8_params.yaml
@@ -327,7 +327,7 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
     src: "mail.*"
     dst: "-/var/log/mail.log"
   kern:
-    src: "kern.*"
+    src: "#kern.*"
     dst: "-/var/log/kern.log"
   messages:
     src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
@@ -336,7 +336,7 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
     src: "cron.*"
     dst: "/var/log/cron"
   secure:
-    src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
+    src: "authpriv.*"
     dst: "-/var/log/secure"
   spooler:
     src: "uucp,news.crit"
@@ -348,10 +348,10 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
     src: "local4.*"
     dst: "/var/log/ldap.log"
   debug:
-    src: "*.debug"
+    src: "#*.debug"
     dst: "/var/log/debug"
   daemon:
-    src: "daemon.*"
+    src: "#daemon.*"
     dst: "/var/log/daemon.log"
 cis_security_hardening::rules::rsyslog_remote_logs::enforce: false
 cis_security_hardening::rules::rsyslog_remote_syslog::enforce: true

--- a/data/cis/cis_RedHat_8_params.yaml
+++ b/data/cis/cis_RedHat_8_params.yaml
@@ -435,17 +435,14 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
   mail:
     src: "mail.*"
     dst: "-/var/log/mail.log"
-  kern:
-    src: "kern.*"
-    dst: "-/var/log/kern.log"
   messages:
-    src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
+    src: "authpriv.*"
     dst: "/var/log/messages"
   cron:
     src: "cron.*"
     dst: "/var/log/cron"
   secure:
-    src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
+    src: "authpriv.*"
     dst: "-/var/log/secure"
   spooler:
     src: "uucp,news.crit"
@@ -457,10 +454,10 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
     src: "local4.*"
     dst: "/var/log/ldap.log"
   debug:
-    src: "*.debug"
+    src: "#*.debug"
     dst: "/var/log/debug"
   daemon:
-    src: "daemon.*"
+    src: "#daemon.*"
     dst: "/var/log/daemon.log"
 cis_security_hardening::rules::rsyslog_remote_logs::enforce: false
 cis_security_hardening::rules::rsyslog_remote_syslog::enforce: true

--- a/data/cis/cis_RedHat_9_params.yaml
+++ b/data/cis/cis_RedHat_9_params.yaml
@@ -392,7 +392,7 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
     src: "mail.*"
     dst: "-/var/log/mail.log"
   kern:
-    src: "kern.*"
+    src: "#kern.*"
     dst: "-/var/log/kern.log"
   messages:
     src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
@@ -401,7 +401,7 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
     src: "cron.*"
     dst: "/var/log/cron"
   secure:
-    src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
+    src: "authpriv.*"
     dst: "-/var/log/secure"
   spooler:
     src: "uucp,news.crit"
@@ -413,10 +413,10 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
     src: "local4.*"
     dst: "/var/log/ldap.log"
   debug:
-    src: "*.debug"
+    src: "#*.debug"
     dst: "/var/log/debug"
   daemon:
-    src: "daemon.*"
+    src: "#daemon.*"
     dst: "/var/log/daemon.log"
 cis_security_hardening::rules::rsyslog_remote_logs::enforce: false
 cis_security_hardening::rules::rsyslog_remote_syslog::enforce: true

--- a/data/cis/cis_Rocky_8_params.yaml
+++ b/data/cis/cis_Rocky_8_params.yaml
@@ -337,7 +337,7 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
     src: "cron.*"
     dst: "/var/log/cron"
   secure:
-    src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
+    src: "authpriv.*"
     dst: "-/var/log/secure"
   spooler:
     src: "uucp,news.crit"

--- a/data/cis/cis_Rocky_9_params.yaml
+++ b/data/cis/cis_Rocky_9_params.yaml
@@ -393,7 +393,7 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
     src: "mail.*"
     dst: "-/var/log/mail.log"
   kern:
-    src: "kern.*"
+    src: "#kern.*"
     dst: "-/var/log/kern.log"
   messages:
     src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
@@ -402,7 +402,7 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
     src: "cron.*"
     dst: "/var/log/cron"
   secure:
-    src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
+    src: "authpriv.*"
     dst: "-/var/log/secure"
   spooler:
     src: "uucp,news.crit"
@@ -414,10 +414,10 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
     src: "local4.*"
     dst: "/var/log/ldap.log"
   debug:
-    src: "*.debug"
+    src: "#*.debug"
     dst: "/var/log/debug"
   daemon:
-    src: "daemon.*"
+    src: "#daemon.*"
     dst: "/var/log/daemon.log"
 cis_security_hardening::rules::rsyslog_remote_logs::enforce: false
 cis_security_hardening::rules::rsyslog_remote_syslog::enforce: true

--- a/manifests/rules/rsyslog_logging.pp
+++ b/manifests/rules/rsyslog_logging.pp
@@ -34,7 +34,7 @@ class cis_security_hardening::rules::rsyslog_logging (
       file { "/etc/rsyslog.d/${config}.conf":
         ensure  => file,
         content => "${src} ${dst}",
-        notify  => Exec['reload-rsyslog'],
+        notify  => Service['rsyslog'],
         require => Package['rsyslog'],
       }
     }


### PR DESCRIPTION
#### Pull Request (PR) description

Fixes rsyslog issues with log messages being logged multiple times in different files and not restarting the service after changes to config

#### This Pull Request (PR) fixes the following issues

Fixes #57 
