### PR TITLE
Avoid dupe logging on Debian, Ubuntu and SLES

### DIFF
--- a/data/cis/cis_Debian_10_params.yaml
+++ b/data/cis/cis_Debian_10_params.yaml
@@ -286,9 +286,6 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
   mail:
     src: "mail.*"
     dst: "-/var/log/mail.log"
-  kern:
-    src: "kern.*"
-    dst: "-/var/log/kern.log"
   messages:
     src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
     dst: "/var/log/messages"
@@ -296,7 +293,7 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
     src: "cron.*"
     dst: "/var/log/cron"
   secure:
-    src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
+    src: "authpriv.*"
     dst: "-/var/log/secure"
   spooler:
     src: "uucp,news.crit"
@@ -304,15 +301,6 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
   boot:
     src: "local7.*"
     dst: "/var/log/boot.log"
-  ldap:
-    src: "local4.*"
-    dst: "/var/log/ldap.log"
-  debug:
-    src: "*.debug"
-    dst: "/var/log/debug"
-  daemon:
-    src: "daemon.*"
-    dst: "/var/log/daemon.log"
 cis_security_hardening::rules::rsyslog_remote_logs::enforce: false
 cis_security_hardening::rules::rsyslog_remote_syslog::enforce: true
 cis_security_hardening::rules::rsyslog_remote_syslog::is_loghost: false

--- a/data/cis/cis_Debian_11_params.yaml
+++ b/data/cis/cis_Debian_11_params.yaml
@@ -309,9 +309,6 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
   mail:
     src: "mail.*"
     dst: "-/var/log/mail.log"
-  kern:
-    src: "kern.*"
-    dst: "-/var/log/kern.log"
   messages:
     src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
     dst: "/var/log/messages"
@@ -319,7 +316,7 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
     src: "cron.*"
     dst: "/var/log/cron"
   secure:
-    src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
+    src: "authpriv.*"
     dst: "-/var/log/secure"
   spooler:
     src: "uucp,news.crit"
@@ -327,15 +324,6 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
   boot:
     src: "local7.*"
     dst: "/var/log/boot.log"
-  ldap:
-    src: "local4.*"
-    dst: "/var/log/ldap.log"
-  debug:
-    src: "*.debug"
-    dst: "/var/log/debug"
-  daemon:
-    src: "daemon.*"
-    dst: "/var/log/daemon.log"
 cis_security_hardening::rules::rsyslog_remote_logs::enforce: false
 cis_security_hardening::rules::rsyslog_remote_syslog::enforce: true
 cis_security_hardening::rules::rsyslog_remote_syslog::is_loghost: false

--- a/data/cis/cis_Debian_12_params.yaml
+++ b/data/cis/cis_Debian_12_params.yaml
@@ -312,9 +312,6 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
   mail:
     src: "mail.*"
     dst: "-/var/log/mail.log"
-  kern:
-    src: "kern.*"
-    dst: "-/var/log/kern.log"
   messages:
     src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
     dst: "/var/log/messages"
@@ -322,7 +319,7 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
     src: "cron.*"
     dst: "/var/log/cron"
   secure:
-    src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
+    src: "authpriv.*"
     dst: "-/var/log/secure"
   spooler:
     src: "uucp,news.crit"
@@ -330,15 +327,6 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
   boot:
     src: "local7.*"
     dst: "/var/log/boot.log"
-  ldap:
-    src: "local4.*"
-    dst: "/var/log/ldap.log"
-  debug:
-    src: "*.debug"
-    dst: "/var/log/debug"
-  daemon:
-    src: "daemon.*"
-    dst: "/var/log/daemon.log"
 cis_security_hardening::rules::rsyslog_remote_logs::enforce: false
 cis_security_hardening::rules::rsyslog_remote_syslog::enforce: true
 cis_security_hardening::rules::rsyslog_remote_syslog::is_loghost: false

--- a/data/cis/cis_SLES_12_params.yaml
+++ b/data/cis/cis_SLES_12_params.yaml
@@ -247,9 +247,6 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
   mail:
     src: "mail.*"
     dst: "-/var/log/mail.log"
-  kern:
-    src: "kern.*"
-    dst: "-/var/log/kern.log"
   messages:
     src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
     dst: "/var/log/messages"
@@ -257,7 +254,7 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
     src: "cron.*"
     dst: "/var/log/cron"
   secure:
-    src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
+    src: "authpriv.*"
     dst: "-/var/log/secure"
   spooler:
     src: "uucp,news.crit"
@@ -265,15 +262,6 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
   boot:
     src: "local7.*"
     dst: "/var/log/boot.log"
-  ldap:
-    src: "local4.*"
-    dst: "/var/log/ldap.log"
-  debug:
-    src: "*.debug"
-    dst: "/var/log/debug"
-  daemon:
-    src: "daemon.*"
-    dst: "/var/log/daemon.log"
 cis_security_hardening::rules::rsyslog_remote_logs::enforce: false
 cis_security_hardening::rules::rsyslog_remote_syslog::enforce: true
 cis_security_hardening::rules::rsyslog_remote_syslog::is_loghost: false

--- a/data/cis/cis_SLES_15_params.yaml
+++ b/data/cis/cis_SLES_15_params.yaml
@@ -282,9 +282,6 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
   mail:
     src: "mail.*"
     dst: "-/var/log/mail.log"
-  kern:
-    src: "kern.*"
-    dst: "-/var/log/kern.log"
   messages:
     src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
     dst: "/var/log/messages"
@@ -292,7 +289,7 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
     src: "cron.*"
     dst: "/var/log/cron"
   secure:
-    src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
+    src: "authpriv.*"
     dst: "-/var/log/secure"
   spooler:
     src: "uucp,news.crit"
@@ -300,15 +297,6 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
   boot:
     src: "local7.*"
     dst: "/var/log/boot.log"
-  ldap:
-    src: "local4.*"
-    dst: "/var/log/ldap.log"
-  debug:
-    src: "*.debug"
-    dst: "/var/log/debug"
-  daemon:
-    src: "daemon.*"
-    dst: "/var/log/daemon.log"
 cis_security_hardening::rules::rsyslog_remote_logs::enforce: false
 cis_security_hardening::rules::rsyslog_remote_syslog::enforce: true
 cis_security_hardening::rules::rsyslog_remote_syslog::is_loghost: false

--- a/data/cis/cis_Ubuntu_18.04_params.yaml
+++ b/data/cis/cis_Ubuntu_18.04_params.yaml
@@ -284,9 +284,6 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
   mail:
     src: "mail.*"
     dst: "-/var/log/mail.log"
-  kern:
-    src: "kern.*"
-    dst: "-/var/log/kern.log"
   messages:
     src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
     dst: "/var/log/messages"
@@ -294,7 +291,7 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
     src: "cron.*"
     dst: "/var/log/cron"
   secure:
-    src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
+    src: "authpriv.*"
     dst: "-/var/log/secure"
   spooler:
     src: "uucp,news.crit"
@@ -302,15 +299,6 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
   boot:
     src: "local7.*"
     dst: "/var/log/boot.log"
-  ldap:
-    src: "local4.*"
-    dst: "/var/log/ldap.log"
-  debug:
-    src: "*.debug"
-    dst: "/var/log/debug"
-  daemon:
-    src: "daemon.*"
-    dst: "/var/log/daemon.log"
 cis_security_hardening::rules::rsyslog_remote_logs::enforce: false
 cis_security_hardening::rules::rsyslog_remote_syslog::enforce: true
 cis_security_hardening::rules::rsyslog_remote_syslog::is_loghost: false

--- a/data/cis/cis_Ubuntu_20.04_params.yaml
+++ b/data/cis/cis_Ubuntu_20.04_params.yaml
@@ -383,9 +383,6 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
   mail:
     src: "mail.*"
     dst: "-/var/log/mail.log"
-  kern:
-    src: "kern.*"
-    dst: "-/var/log/kern.log"
   messages:
     src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
     dst: "/var/log/messages"
@@ -393,7 +390,7 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
     src: "cron.*"
     dst: "/var/log/cron"
   secure:
-    src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
+    src: "authpriv.*"
     dst: "-/var/log/secure"
   spooler:
     src: "uucp,news.crit"
@@ -401,15 +398,6 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
   boot:
     src: "local7.*"
     dst: "/var/log/boot.log"
-  ldap:
-    src: "local4.*"
-    dst: "/var/log/ldap.log"
-  debug:
-    src: "*.debug"
-    dst: "/var/log/debug"
-  daemon:
-    src: "daemon.*"
-    dst: "/var/log/daemon.log"
 cis_security_hardening::rules::rsyslog_remote_logs::enforce: false
 cis_security_hardening::rules::rsyslog_remote_syslog::enforce: true
 cis_security_hardening::rules::rsyslog_remote_syslog::is_loghost: false

--- a/data/cis/cis_Ubuntu_22.04_params.yaml
+++ b/data/cis/cis_Ubuntu_22.04_params.yaml
@@ -388,9 +388,6 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
   mail:
     src: "mail.*"
     dst: "-/var/log/mail.log"
-  kern:
-    src: "kern.*"
-    dst: "-/var/log/kern.log"
   messages:
     src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
     dst: "/var/log/messages"
@@ -398,7 +395,7 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
     src: "cron.*"
     dst: "/var/log/cron"
   secure:
-    src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
+    src: "authpriv.*"
     dst: "-/var/log/secure"
   spooler:
     src: "uucp,news.crit"
@@ -406,15 +403,6 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
   boot:
     src: "local7.*"
     dst: "/var/log/boot.log"
-  ldap:
-    src: "local4.*"
-    dst: "/var/log/ldap.log"
-  debug:
-    src: "*.debug"
-    dst: "/var/log/debug"
-  daemon:
-    src: "daemon.*"
-    dst: "/var/log/daemon.log"
 cis_security_hardening::rules::rsyslog_remote_logs::enforce: false
 cis_security_hardening::rules::rsyslog_remote_syslog::enforce: true
 cis_security_hardening::rules::rsyslog_remote_syslog::is_loghost: false

--- a/data/cis/cis_Ubuntu_24.04_params.yaml
+++ b/data/cis/cis_Ubuntu_24.04_params.yaml
@@ -396,9 +396,6 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
   mail:
     src: "mail.*"
     dst: "-/var/log/mail.log"
-  kern:
-    src: "kern.*"
-    dst: "-/var/log/kern.log"
   messages:
     src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
     dst: "/var/log/messages"
@@ -406,7 +403,7 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
     src: "cron.*"
     dst: "/var/log/cron"
   secure:
-    src: "*.info;mail.none;authpriv.none;cron.none;local0.none"
+    src: "authpriv.*"
     dst: "-/var/log/secure"
   spooler:
     src: "uucp,news.crit"
@@ -414,15 +411,6 @@ cis_security_hardening::rules::rsyslog_logging::log_config:
   boot:
     src: "local7.*"
     dst: "/var/log/boot.log"
-  ldap:
-    src: "local4.*"
-    dst: "/var/log/ldap.log"
-  debug:
-    src: "*.debug"
-    dst: "/var/log/debug"
-  daemon:
-    src: "daemon.*"
-    dst: "/var/log/daemon.log"
 cis_security_hardening::rules::rsyslog_remote_logs::enforce: false
 cis_security_hardening::rules::rsyslog_remote_syslog::enforce: true
 cis_security_hardening::rules::rsyslog_remote_syslog::is_loghost: false


### PR DESCRIPTION
#### Pull Request (PR) description

Avoid dupe logging on Debian, Ubuntu and SLES in the default params for those OSes.

#### This Pull Request (PR) fixes the following issues

Fixes https://github.com/bwitt/cis_security_hardening/issues/62
