### PR TITLE
Fix systemd_timesyncd fallback NTP parameter name

### DIFF
--- a/data/cis/cis_Debian_10_params.yaml
+++ b/data/cis/cis_Debian_10_params.yaml
@@ -89,7 +89,7 @@ cis_security_hardening::rules::systemd_timesyncd::ntp_servers:
   - 0.de.pool.ntp.org
   - 1.de.pool.ntp.org
   - 3.de.pool.ntp.org
-cis_security_hardening::rules::systemd_timesyncd::ntp_fallback_server:
+cis_security_hardening::rules::systemd_timesyncd::ntp_fallback_servers:
   - 3.de.pool.ntp.org
 cis_security_hardening::rules::chrony::enforce: false
 cis_security_hardening::rules::chrony::ntp_servers: ~

--- a/data/cis/cis_Debian_11_params.yaml
+++ b/data/cis/cis_Debian_11_params.yaml
@@ -105,7 +105,7 @@ cis_security_hardening::rules::systemd_timesyncd::ntp_servers:
   - 0.de.pool.ntp.org
   - 1.de.pool.ntp.org
   - 3.de.pool.ntp.org
-cis_security_hardening::rules::systemd_timesyncd::ntp_fallback_server:
+cis_security_hardening::rules::systemd_timesyncd::ntp_fallback_servers:
   - 3.de.pool.ntp.org
 cis_security_hardening::rules::chrony::enforce: false
 cis_security_hardening::rules::chrony::ntp_servers: ~

--- a/data/cis/cis_Debian_12_params.yaml
+++ b/data/cis/cis_Debian_12_params.yaml
@@ -104,7 +104,7 @@ cis_security_hardening::rules::systemd_timesyncd::ntp_servers:
   - 0.de.pool.ntp.org
   - 1.de.pool.ntp.org
   - 3.de.pool.ntp.org
-cis_security_hardening::rules::systemd_timesyncd::ntp_fallback_server:
+cis_security_hardening::rules::systemd_timesyncd::ntp_fallback_servers:
   - 3.de.pool.ntp.org
 cis_security_hardening::rules::chrony::enforce: false
 cis_security_hardening::rules::chrony::ntp_servers: ~

--- a/data/cis/cis_SLES_12_params.yaml
+++ b/data/cis/cis_SLES_12_params.yaml
@@ -94,7 +94,7 @@ cis_security_hardening::rules::systemd_timesyncd::ntp_servers:
   - 0.de.pool.ntp.org
   - 1.de.pool.ntp.org
   - 3.de.pool.ntp.org
-cis_security_hardening::rules::systemd_timesyncd::ntp_fallback_server:
+cis_security_hardening::rules::systemd_timesyncd::ntp_fallback_servers:
   - 3.de.pool.ntp.org
 cis_security_hardening::rules::chrony::enforce: false
 cis_security_hardening::rules::chrony::ntp_servers: ~

--- a/data/cis/cis_SLES_15_params.yaml
+++ b/data/cis/cis_SLES_15_params.yaml
@@ -95,7 +95,7 @@ cis_security_hardening::rules::systemd_timesyncd::ntp_servers:
   - 0.de.pool.ntp.org
   - 1.de.pool.ntp.org
   - 3.de.pool.ntp.org
-cis_security_hardening::rules::systemd_timesyncd::ntp_fallback_server:
+cis_security_hardening::rules::systemd_timesyncd::ntp_fallback_servers:
   - 3.de.pool.ntp.org
 cis_security_hardening::rules::chrony::enforce: false
 cis_security_hardening::rules::chrony::ntp_servers: ~

--- a/data/cis/cis_Ubuntu_18.04_params.yaml
+++ b/data/cis/cis_Ubuntu_18.04_params.yaml
@@ -87,7 +87,7 @@ cis_security_hardening::rules::systemd_timesyncd::ntp_servers:
   - 0.de.pool.ntp.org
   - 1.de.pool.ntp.org
   - 3.de.pool.ntp.org
-cis_security_hardening::rules::systemd_timesyncd::ntp_fallback_server:
+cis_security_hardening::rules::systemd_timesyncd::ntp_fallback_servers:
   - 3.de.pool.ntp.org
 cis_security_hardening::rules::chrony::enforce: false
 cis_security_hardening::rules::chrony::ntp_servers: ~

--- a/data/cis/cis_Ubuntu_20.04_params.yaml
+++ b/data/cis/cis_Ubuntu_20.04_params.yaml
@@ -111,7 +111,7 @@ cis_security_hardening::rules::systemd_timesyncd::ntp_servers:
   - 0.de.pool.ntp.org
   - 1.de.pool.ntp.org
   - 3.de.pool.ntp.org
-cis_security_hardening::rules::systemd_timesyncd::ntp_fallback_server:
+cis_security_hardening::rules::systemd_timesyncd::ntp_fallback_servers:
   - 3.de.pool.ntp.org
 cis_security_hardening::rules::chrony::enforce: false
 cis_security_hardening::rules::chrony::ntp_servers: ~

--- a/data/cis/cis_Ubuntu_22.04_params.yaml
+++ b/data/cis/cis_Ubuntu_22.04_params.yaml
@@ -108,7 +108,7 @@ cis_security_hardening::rules::systemd_timesyncd::ntp_servers:
   - 0.de.pool.ntp.org
   - 1.de.pool.ntp.org
   - 3.de.pool.ntp.org
-cis_security_hardening::rules::systemd_timesyncd::ntp_fallback_server:
+cis_security_hardening::rules::systemd_timesyncd::ntp_fallback_servers:
   - 3.de.pool.ntp.org
 cis_security_hardening::rules::chrony::enforce: false
 cis_security_hardening::rules::chrony::ntp_servers: ~

--- a/data/cis/cis_Ubuntu_24.04_params.yaml
+++ b/data/cis/cis_Ubuntu_24.04_params.yaml
@@ -111,7 +111,7 @@ cis_security_hardening::rules::ctrl_alt_del_graphical::enforce: true
 cis_security_hardening::rules::systemd_timesyncd::enforce: false
 cis_security_hardening::rules::systemd_timesyncd::fix_file_perms: true
 cis_security_hardening::rules::systemd_timesyncd::ntp_servers: ~
-cis_security_hardening::rules::systemd_timesyncd::ntp_fallback_server: ~
+cis_security_hardening::rules::systemd_timesyncd::ntp_fallback_servers: ~
 cis_security_hardening::rules::chrony::enforce: true
 cis_security_hardening::rules::chrony::ntp_servers:
   0.pool.ntp.org:


### PR DESCRIPTION
#### Pull Request (PR) description

Fix `ntp_fallback_server` -> `ntp_fallback_servers` in the per OS param files.

#### This Pull Request (PR) fixes the following issues

None
