### PR TITLE
Fix unreachable action/queue validation in ufw rules

### DIFF
--- a/manifests/rules/ufw_open_ports.pp
+++ b/manifests/rules/ufw_open_ports.pp
@@ -25,7 +25,7 @@ class cis_security_hardening::rules::ufw_open_ports (
   if $enforce {
     $firewall_rules.each |$title, $data| {
       if cis_security_hardening::hash_key($data, 'action') {
-        unless $data['action'] =~ /\W*/ {
+        unless $data['action'] =~ /^(allow|deny|reject|limit)$/ {
           fail("Illegal action: ${data['action']}")
         }
         $action = $data['action']
@@ -34,7 +34,7 @@ class cis_security_hardening::rules::ufw_open_ports (
       }
 
       if cis_security_hardening::hash_key($data, 'queue') {
-        unless $data['queue'] =~ /\W*/ {
+        unless $data['queue'] =~ /^(in|out)$/ {
           fail("Illegal queue: ${data['queue']}")
         }
         $queue = $data['queue']

--- a/manifests/rules/ufw_outbound.pp
+++ b/manifests/rules/ufw_outbound.pp
@@ -26,7 +26,7 @@ class cis_security_hardening::rules::ufw_outbound (
   if $enforce {
     $firewall_rules.each |$title, $data| {
       if cis_security_hardening::hash_key($data, 'action') {
-        unless $data['action'] =~ /\W*/ {
+        unless $data['action'] =~ /^(allow|deny|reject|limit)$/ {
           fail("Illegal action: ${data['action']}")
         }
         $action = $data['action']
@@ -35,7 +35,7 @@ class cis_security_hardening::rules::ufw_outbound (
       }
 
       if cis_security_hardening::hash_key($data, 'queue') {
-        unless $data['queue'] =~ /\W*/ {
+        unless $data['queue'] =~ /^(in|out)$/ {
           fail("Illegal queue: ${data['queue']}")
         }
         $queue = $data['queue']

--- a/spec/classes/rules/ufw_open_ports_spec.rb
+++ b/spec/classes/rules/ufw_open_ports_spec.rb
@@ -116,5 +116,47 @@ describe 'cis_security_hardening::rules::ufw_open_ports' do
         }
       end
     end
+
+    context "on #{os} with an illegal action" do
+      let(:facts) { os_facts }
+      let(:params) do
+        {
+          'enforce' => true,
+          'firewall_rules' => {
+            'bad action' => {
+              'queue' => 'in',
+              'from' => 'any',
+              'to' => 'any',
+              'port' => '22',
+              'proto' => 'tcp',
+              'action' => 'allow; rm -rf /',
+            },
+          },
+        }
+      end
+
+      it { is_expected.to compile.and_raise_error(%r{Illegal action: allow; rm -rf /}) }
+    end
+
+    context "on #{os} with an illegal queue" do
+      let(:facts) { os_facts }
+      let(:params) do
+        {
+          'enforce' => true,
+          'firewall_rules' => {
+            'bad queue' => {
+              'queue' => 'sideways',
+              'from' => 'any',
+              'to' => 'any',
+              'port' => '22',
+              'proto' => 'tcp',
+              'action' => 'allow',
+            },
+          },
+        }
+      end
+
+      it { is_expected.to compile.and_raise_error(%r{Illegal queue: sideways}) }
+    end
   end
 end

--- a/spec/classes/rules/ufw_outbound_spec.rb
+++ b/spec/classes/rules/ufw_outbound_spec.rb
@@ -91,5 +91,45 @@ describe 'cis_security_hardening::rules::ufw_outbound' do
         }
       end
     end
+
+    context "on #{os} with an illegal action" do
+      let(:facts) { os_facts }
+      let(:params) do
+        {
+          'enforce' => true,
+          'firewall_rules' => {
+            'bad action' => {
+              'queue' => 'out',
+              'to' => 'any',
+              'port' => '53',
+              'proto' => 'udp',
+              'action' => 'allow; rm -rf /',
+            },
+          },
+        }
+      end
+
+      it { is_expected.to compile.and_raise_error(%r{Illegal action: allow; rm -rf /}) }
+    end
+
+    context "on #{os} with an illegal queue" do
+      let(:facts) { os_facts }
+      let(:params) do
+        {
+          'enforce' => true,
+          'firewall_rules' => {
+            'bad queue' => {
+              'queue' => 'sideways',
+              'to' => 'any',
+              'port' => '53',
+              'proto' => 'udp',
+              'action' => 'allow',
+            },
+          },
+        }
+      end
+
+      it { is_expected.to compile.and_raise_error(%r{Illegal queue: sideways}) }
+    end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description

`\W*` matches the empty string, so it always matches and never hits `fail()`.

Replace with anchored allow-lists and adds negative specs.

#### This Pull Request (PR) fixes the following issues

None
