### PR TITLE
Fix grub password `user.cfg` newline and update-grub invocation

### DIFF
--- a/manifests/rules/grub_password.pp
+++ b/manifests/rules/grub_password.pp
@@ -51,7 +51,7 @@ class cis_security_hardening::rules::grub_password (
         'redhat': {
           file { "${grub_path}/user.cfg":
             ensure  => file,
-            content => "GRUB2_PASSWORD=${grub_password_pbkdf2}",
+            content => "GRUB2_PASSWORD=${grub_password_pbkdf2}\n",
             owner   => 'root',
             group   => 'root',
             mode    => fact('cis_security_hardening.efi') ? { true => '0700', default => '0600' },
@@ -86,10 +86,7 @@ class cis_security_hardening::rules::grub_password (
           }
 
           exec { 'bootpw-grub-config-ubuntu':
-            command     => fact('cis_security_hardening.efi') ? {
-              true    => "update-grub -o ${grub_path}/grub.cfg",
-              default => 'update-grub'
-            },
+            command     => 'update-grub',
             path        => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
             refreshonly => true,
           }

--- a/spec/classes/rules/grub_password_spec.rb
+++ b/spec/classes/rules/grub_password_spec.rb
@@ -62,10 +62,11 @@ describe 'cis_security_hardening::rules::grub_password' do
               if enforce
                 is_expected.to contain_file("#{grub_path}/user.cfg").
                   with(
-                    'ensure' => 'file',
-                    'owner'  => 'root',
-                    'group'  => 'root',
-                    'mode'   => mode
+                    'ensure'  => 'file',
+                    'owner'   => 'root',
+                    'group'   => 'root',
+                    'mode'    => mode,
+                    'content' => "GRUB2_PASSWORD=grub.pbkdf2.sha512.10000.943.....\n"
                   ).
                   that_notifies('Exec[bootpw-grub-config]')
 
@@ -80,11 +81,7 @@ describe 'cis_security_hardening::rules::grub_password' do
 
             elsif os_facts[:os]['family'].casecmp('debian').zero?
 
-              command = if efi
-                          "update-grub -o #{grub_path}/grub.cfg"
-                        else
-                          'update-grub'
-                        end
+              command = 'update-grub'
 
               is_expected.not_to contain_file("#{grub_path}/user.cfg")
               is_expected.not_to contain_exec('bootpw-grub-config')


### PR DESCRIPTION
#### Pull Request (PR) description

Add trailing newline to user.cfg.
`update-grub` does not take an argument, so remove that argument.

#### This Pull Request (PR) fixes the following issues

None
