### PR TITLE
Fix `postrun_command` `file_line` placement in puppet.conf

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -58,15 +58,7 @@ class cis_security_hardening::config (
     if fact('cis_security_hardening.puppet_agent_postrun') != "postrun_command = ${fact_upload_command}" {
       file_line { 'append postrun command agent':
         path               => '/etc/puppetlabs/puppet/puppet.conf',
-        after              => '[agent]',
-        match              => 'postrun_command\s*=',
-        line               => "postrun_command = ${fact_upload_command}",
-        append_on_no_match => true,
-      }
-
-      file_line { 'append postrun command main':
-        path               => '/etc/puppetlabs/puppet/puppet.conf',
-        after              => 'certname\s*=.*',
+        after              => '^\[agent\]',
         match              => 'postrun_command\s*=',
         line               => "postrun_command = ${fact_upload_command}",
         append_on_no_match => true,

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -61,20 +61,13 @@ describe 'cis_security_hardening::config' do
             is_expected.to contain_file_line('append postrun command agent').
               with(
                 'path'               => '/etc/puppetlabs/puppet/puppet.conf',
-                'after'              => '[agent]',
+                'after'              => '^\[agent\]',
                 'match'              => 'postrun_command\s*=',
                 'line'               => 'postrun_command = /usr/share/cis_security_hardening/bin/fact_upload.sh',
                 'append_on_no_match' => true
               )
 
-            is_expected.to contain_file_line('append postrun command main').
-              with(
-                'path'               => '/etc/puppetlabs/puppet/puppet.conf',
-                'after'              => 'certname\s*=.*',
-                'match'              => 'postrun_command\s*=',
-                'line'               => 'postrun_command = /usr/share/cis_security_hardening/bin/fact_upload.sh',
-                'append_on_no_match' => true
-              )
+            is_expected.not_to contain_file_line('append postrun command main')
           else
             is_expected.not_to contain_file_line('append postrun command main')
             is_expected.not_to contain_file_line('append postrun command agent')


### PR DESCRIPTION
#### Pull Request (PR) description

Fix the `[agent]` match for adding `postrun_command`.
Remove the duplicate postrun addition.

#### This Pull Request (PR) fixes the following issues

None
