### PR TITLE
Fix `ufw_default_deny` `default_routed` parameter name

### DIFF
--- a/data/cis/cis_Debian_10_params.yaml
+++ b/data/cis/cis_Debian_10_params.yaml
@@ -156,7 +156,7 @@ cis_security_hardening::rules::ufw_open_ports::enforce: false
 cis_security_hardening::rules::ufw_default_deny::enforce: false
 cis_security_hardening::rules::ufw_default_deny::default_incoming: allow
 cis_security_hardening::rules::ufw_default_deny::default_outgoing: allow
-cis_security_hardening::rules::ufw_default_deny::routed: allow
+cis_security_hardening::rules::ufw_default_deny::default_routed: allow
 
 cis_security_hardening::rules::nftables_install::enforce: false
 cis_security_hardening::rules::nftables_flush_iptables::enforce: false

--- a/data/cis/cis_Debian_11_params.yaml
+++ b/data/cis/cis_Debian_11_params.yaml
@@ -173,7 +173,7 @@ cis_security_hardening::rules::ufw_open_ports::enforce: false
 cis_security_hardening::rules::ufw_default_deny::enforce: false
 cis_security_hardening::rules::ufw_default_deny::default_incoming: allow
 cis_security_hardening::rules::ufw_default_deny::default_outgoing: allow
-cis_security_hardening::rules::ufw_default_deny::routed: allow
+cis_security_hardening::rules::ufw_default_deny::default_routed: allow
 
 cis_security_hardening::rules::nftables_install::enforce: false
 cis_security_hardening::rules::nftables_flush_iptables::enforce: false

--- a/data/cis/cis_Debian_12_params.yaml
+++ b/data/cis/cis_Debian_12_params.yaml
@@ -176,7 +176,7 @@ cis_security_hardening::rules::ufw_open_ports::enforce: false
 cis_security_hardening::rules::ufw_default_deny::enforce: false
 cis_security_hardening::rules::ufw_default_deny::default_incoming: allow
 cis_security_hardening::rules::ufw_default_deny::default_outgoing: allow
-cis_security_hardening::rules::ufw_default_deny::routed: allow
+cis_security_hardening::rules::ufw_default_deny::default_routed: allow
 
 cis_security_hardening::rules::nftables_install::enforce: false
 cis_security_hardening::rules::nftables_flush_iptables::enforce: false

--- a/data/cis/cis_Ubuntu_18.04_params.yaml
+++ b/data/cis/cis_Ubuntu_18.04_params.yaml
@@ -154,7 +154,7 @@ cis_security_hardening::rules::ufw_open_ports::enforce: false
 cis_security_hardening::rules::ufw_default_deny::enforce: false
 cis_security_hardening::rules::ufw_default_deny::default_incoming: allow
 cis_security_hardening::rules::ufw_default_deny::default_outgoing: allow
-cis_security_hardening::rules::ufw_default_deny::routed: allow
+cis_security_hardening::rules::ufw_default_deny::default_routed: allow
 
 cis_security_hardening::rules::nftables_install::enforce: false
 cis_security_hardening::rules::nftables_flush_iptables::enforce: false

--- a/data/cis/cis_Ubuntu_20.04_params.yaml
+++ b/data/cis/cis_Ubuntu_20.04_params.yaml
@@ -187,7 +187,7 @@ cis_security_hardening::rules::ufw_open_ports::enforce: false
 cis_security_hardening::rules::ufw_default_deny::enforce: false
 cis_security_hardening::rules::ufw_default_deny::default_incoming: allow
 cis_security_hardening::rules::ufw_default_deny::default_outgoing: allow
-cis_security_hardening::rules::ufw_default_deny::routed: allow
+cis_security_hardening::rules::ufw_default_deny::default_routed: allow
 
 cis_security_hardening::rules::nftables_install::enforce: false
 cis_security_hardening::rules::nftables_flush_iptables::enforce: false

--- a/data/cis/cis_Ubuntu_22.04_params.yaml
+++ b/data/cis/cis_Ubuntu_22.04_params.yaml
@@ -183,7 +183,7 @@ cis_security_hardening::rules::ufw_open_ports::enforce: false
 cis_security_hardening::rules::ufw_default_deny::enforce: false
 cis_security_hardening::rules::ufw_default_deny::default_incoming: allow
 cis_security_hardening::rules::ufw_default_deny::default_outgoing: allow
-cis_security_hardening::rules::ufw_default_deny::routed: allow
+cis_security_hardening::rules::ufw_default_deny::default_routed: allow
 
 cis_security_hardening::rules::nftables_install::enforce: false
 cis_security_hardening::rules::nftables_flush_iptables::enforce: false

--- a/data/cis/cis_Ubuntu_24.04_params.yaml
+++ b/data/cis/cis_Ubuntu_24.04_params.yaml
@@ -221,7 +221,7 @@ cis_security_hardening::rules::ufw_open_ports::firewall_rules:
 cis_security_hardening::rules::ufw_default_deny::enforce: true
 cis_security_hardening::rules::ufw_default_deny::default_incoming: deny
 cis_security_hardening::rules::ufw_default_deny::default_outgoing: allow
-cis_security_hardening::rules::ufw_default_deny::routed: deny
+cis_security_hardening::rules::ufw_default_deny::default_routed: deny
 
 cis_security_hardening::rules::nftables_install::enforce: false
 cis_security_hardening::rules::nftables_flush_iptables::enforce: false


### PR DESCRIPTION
#### Pull Request (PR) description

Fix setting `default_routed` in the param files for Ubuntu and Debian; Ubuntu 24.04 enables this by default so this is a change to the defaults.  The other OSes do not enable ufw.

#### This Pull Request (PR) fixes the following issues

None
