### PR TITLE
Add Ubuntu support for opassword_perms (CIS 7.1.10)

### DIFF
--- a/data/cis/cis_Ubuntu_18.04_params.yaml
+++ b/data/cis/cis_Ubuntu_18.04_params.yaml
@@ -435,6 +435,7 @@ cis_security_hardening::rules::shadow_perms::enforce: true
 cis_security_hardening::rules::group_perms::enforce: true
 cis_security_hardening::rules::gshadow_perms::enforce: true
 cis_security_hardening::rules::shells_perms::enforce: true
+cis_security_hardening::rules::opassword_perms::enforce: true
 cis_security_hardening::rules::passwd_bak_perms::enforce: true
 cis_security_hardening::rules::group_bak_perms::enforce: true
 cis_security_hardening::rules::shadow_bak_perms::enforce: true

--- a/data/cis/cis_Ubuntu_18.04_rules.yaml
+++ b/data/cis/cis_Ubuntu_18.04_rules.yaml
@@ -248,6 +248,7 @@ cis_security_hardening::benchmark::ubuntu::v18:
         - gshadow_perms
         - gshadow_bak_perms
         - shells_perms
+        - opassword_perms
     configure_user_groups:
       level1:
         - shadowed_passwords

--- a/data/cis/cis_Ubuntu_20.04_params.yaml
+++ b/data/cis/cis_Ubuntu_20.04_params.yaml
@@ -557,6 +557,7 @@ cis_security_hardening::rules::shadow_perms::enforce: true
 cis_security_hardening::rules::group_perms::enforce: true
 cis_security_hardening::rules::gshadow_perms::enforce: true
 cis_security_hardening::rules::shells_perms::enforce: true
+cis_security_hardening::rules::opassword_perms::enforce: true
 cis_security_hardening::rules::passwd_bak_perms::enforce: true
 cis_security_hardening::rules::group_bak_perms::enforce: true
 cis_security_hardening::rules::shadow_bak_perms::enforce: true

--- a/data/cis/cis_Ubuntu_20.04_rules.yaml
+++ b/data/cis/cis_Ubuntu_20.04_rules.yaml
@@ -339,6 +339,7 @@ cis_security_hardening::benchmark::ubuntu::v20:
         - gshadow_perms
         - gshadow_bak_perms
         - shells_perms
+        - opassword_perms
     configure_user_groups:
       level1:
         - shadowed_passwords

--- a/data/cis/cis_Ubuntu_22.04_params.yaml
+++ b/data/cis/cis_Ubuntu_22.04_params.yaml
@@ -561,6 +561,7 @@ cis_security_hardening::rules::shadow_perms::enforce: true
 cis_security_hardening::rules::group_perms::enforce: true
 cis_security_hardening::rules::gshadow_perms::enforce: true
 cis_security_hardening::rules::shells_perms::enforce: true
+cis_security_hardening::rules::opassword_perms::enforce: true
 cis_security_hardening::rules::passwd_bak_perms::enforce: true
 cis_security_hardening::rules::group_bak_perms::enforce: true
 cis_security_hardening::rules::shadow_bak_perms::enforce: true

--- a/data/cis/cis_Ubuntu_22.04_rules.yaml
+++ b/data/cis/cis_Ubuntu_22.04_rules.yaml
@@ -275,6 +275,7 @@ cis_security_hardening::benchmark::ubuntu::v22:
         - gshadow_perms
         - gshadow_bak_perms
         - shells_perms
+        - opassword_perms
     configure_user_groups:
       level1:
         - shadowed_passwords

--- a/data/cis/cis_Ubuntu_24.04_params.yaml
+++ b/data/cis/cis_Ubuntu_24.04_params.yaml
@@ -581,6 +581,7 @@ cis_security_hardening::rules::shadow_perms::enforce: true
 cis_security_hardening::rules::group_perms::enforce: true
 cis_security_hardening::rules::gshadow_perms::enforce: true
 cis_security_hardening::rules::shells_perms::enforce: true
+cis_security_hardening::rules::opassword_perms::enforce: true
 cis_security_hardening::rules::passwd_bak_perms::enforce: true
 cis_security_hardening::rules::group_bak_perms::enforce: true
 cis_security_hardening::rules::shadow_bak_perms::enforce: true

--- a/data/cis/cis_Ubuntu_24.04_rules.yaml
+++ b/data/cis/cis_Ubuntu_24.04_rules.yaml
@@ -295,6 +295,7 @@ cis_security_hardening::benchmark::ubuntu::v24:
         - gshadow_perms
         - gshadow_bak_perms
         - shells_perms
+        - opassword_perms
     configure_user_groups:
       level1:
         - shadowed_passwords


### PR DESCRIPTION
## Summary
- `/etc/security/opasswd` permissions (CIS 7.1.10) were never wired up for any Ubuntu release — same gap as `shells_perms` (#61), confirmed missing from all four `data/cis/cis_Ubuntu_*` params/rules files.
- Adds `opassword_perms` to `system_file_permissions` level1 and sets `enforce: true` for Ubuntu 18.04, 20.04, 22.04, and 24.04, following the same pattern used for `shells_perms` and `disable_bluetooth` (2f147ed).

## Test plan
- [x] `bundle exec rspec spec/classes/rules/opassword_perms_spec.rb` — 29 examples, 0 failures (covers Ubuntu among all supported OSes)
- [x] `bundle exec rake validate` — clean
- [x] `bundle exec rake lint` — clean
- [x] `bundle exec rake rubocop` — 461 files inspected, no offenses
- [x] `bundle exec rake spec` (full suite) — 15774 examples, 0 failures

Functional verification — built Ubuntu 24.04 and 22.04 containers with real Puppet 8 and the actual `cis_security_hardening::rules::opassword_perms` class, applied with `enforce => true`:
- [x] Confirmed pre-existing state on both releases: `/etc/security/opasswd` already exists with `0600 root:root` (Ubuntu ships it correctly by default); `/etc/security/opasswd.old` does not exist
- [x] `puppet apply` created `/etc/security/opasswd.old` with `0600 root:root` on both releases; `/etc/security/opasswd` was left untouched (already compliant)
- [x] Re-ran `puppet apply` on both — exit code `0`, no changes (idempotent)
- [x] Confirmed `enforce: false` declares zero resources (true no-op) via the class's own spec
