### PR TITLE
Ensure /dev/shm has an fstab entry before dev_shm_nodev/noexec/nosuid edit it

### DIFF
--- a/manifests/rules/dev_shm_nodev.pp
+++ b/manifests/rules/dev_shm_nodev.pp
@@ -20,6 +20,19 @@ class cis_security_hardening::rules::dev_shm_nodev (
   Boolean $enforce = false,
 ) {
   if ($enforce) and cis_security_hardening::hash_key($facts['mountpoints'], '/dev/shm') {
+    # /dev/shm is normally kernel/systemd-mounted with no /etc/fstab entry, which
+    # set_mount_options requires in order to edit it. Ensure a baseline entry
+    # exists first; leave any pre-existing entry (e.g. a configured size) untouched.
+    file_line { 'ensure /dev/shm fstab entry exists (nodev)':
+      ensure             => present,
+      path               => '/etc/fstab',
+      match              => '^\S+\s+/dev/shm\s',
+      line               => 'tmpfs   /dev/shm        tmpfs   defaults   0 0',
+      append_on_no_match => true,
+      replace            => false,
+      before             => Cis_security_hardening::Set_mount_options['/dev/shm-nodev'],
+    }
+
     cis_security_hardening::set_mount_options { '/dev/shm-nodev':
       mountpoint   => '/dev/shm',
       mountoptions => 'nodev',

--- a/manifests/rules/dev_shm_noexec.pp
+++ b/manifests/rules/dev_shm_noexec.pp
@@ -20,6 +20,19 @@ class cis_security_hardening::rules::dev_shm_noexec (
   Boolean $enforce = false,
 ) {
   if ($enforce) and cis_security_hardening::hash_key($facts['mountpoints'], '/dev/shm') {
+    # /dev/shm is normally kernel/systemd-mounted with no /etc/fstab entry, which
+    # set_mount_options requires in order to edit it. Ensure a baseline entry
+    # exists first; leave any pre-existing entry (e.g. a configured size) untouched.
+    file_line { 'ensure /dev/shm fstab entry exists (noexec)':
+      ensure             => present,
+      path               => '/etc/fstab',
+      match              => '^\S+\s+/dev/shm\s',
+      line               => 'tmpfs   /dev/shm        tmpfs   defaults   0 0',
+      append_on_no_match => true,
+      replace            => false,
+      before             => Cis_security_hardening::Set_mount_options['/dev/shm-noexec'],
+    }
+
     cis_security_hardening::set_mount_options { '/dev/shm-noexec':
       mountpoint   => '/dev/shm',
       mountoptions => 'noexec',

--- a/manifests/rules/dev_shm_nosuid.pp
+++ b/manifests/rules/dev_shm_nosuid.pp
@@ -20,6 +20,19 @@ class cis_security_hardening::rules::dev_shm_nosuid (
   Boolean $enforce = false,
 ) {
   if ($enforce) and cis_security_hardening::hash_key($facts['mountpoints'], '/dev/shm') {
+    # /dev/shm is normally kernel/systemd-mounted with no /etc/fstab entry, which
+    # set_mount_options requires in order to edit it. Ensure a baseline entry
+    # exists first; leave any pre-existing entry (e.g. a configured size) untouched.
+    file_line { 'ensure /dev/shm fstab entry exists (nosuid)':
+      ensure             => present,
+      path               => '/etc/fstab',
+      match              => '^\S+\s+/dev/shm\s',
+      line               => 'tmpfs   /dev/shm        tmpfs   defaults   0 0',
+      append_on_no_match => true,
+      replace            => false,
+      before             => Cis_security_hardening::Set_mount_options['/dev/shm-nosuid'],
+    }
+
     cis_security_hardening::set_mount_options { '/dev/shm-nosuid':
       mountpoint   => '/dev/shm',
       mountoptions => 'nosuid',

--- a/spec/classes/rules/dev_shm_nodev_spec.rb
+++ b/spec/classes/rules/dev_shm_nodev_spec.rb
@@ -39,8 +39,16 @@ describe 'cis_security_hardening::rules::dev_shm_nodev' do
                 'mountpoint'   => '/dev/shm',
                 'mountoptions' => 'nodev'
               )
+            is_expected.to contain_file_line('ensure /dev/shm fstab entry exists (nodev)').
+              with(
+                'path'               => '/etc/fstab',
+                'append_on_no_match' => true,
+                'replace'            => false
+              ).
+              that_comes_before('Cis_security_hardening::Set_mount_options[/dev/shm-nodev]')
           else
             is_expected.not_to contain_cis_security_hardening__set_mount_options('/dev/shm-nodev')
+            is_expected.not_to contain_file_line('ensure /dev/shm fstab entry exists (nodev)')
           end
         }
       end

--- a/spec/classes/rules/dev_shm_noexec_spec.rb
+++ b/spec/classes/rules/dev_shm_noexec_spec.rb
@@ -39,8 +39,16 @@ describe 'cis_security_hardening::rules::dev_shm_noexec' do
                 'mountpoint'   => '/dev/shm',
                 'mountoptions' => 'noexec'
               )
+            is_expected.to contain_file_line('ensure /dev/shm fstab entry exists (noexec)').
+              with(
+                'path'               => '/etc/fstab',
+                'append_on_no_match' => true,
+                'replace'            => false
+              ).
+              that_comes_before('Cis_security_hardening::Set_mount_options[/dev/shm-noexec]')
           else
             is_expected.not_to contain_cis_security_hardening__set_mount_options('/dev/shm-noexec')
+            is_expected.not_to contain_file_line('ensure /dev/shm fstab entry exists (noexec)')
           end
         }
       end

--- a/spec/classes/rules/dev_shm_nosuid_spec.rb
+++ b/spec/classes/rules/dev_shm_nosuid_spec.rb
@@ -39,8 +39,16 @@ describe 'cis_security_hardening::rules::dev_shm_nosuid' do
                 'mountpoint'   => '/dev/shm',
                 'mountoptions' => 'nosuid'
               )
+            is_expected.to contain_file_line('ensure /dev/shm fstab entry exists (nosuid)').
+              with(
+                'path'               => '/etc/fstab',
+                'append_on_no_match' => true,
+                'replace'            => false
+              ).
+              that_comes_before('Cis_security_hardening::Set_mount_options[/dev/shm-nosuid]')
           else
             is_expected.not_to contain_cis_security_hardening__set_mount_options('/dev/shm-nosuid')
+            is_expected.not_to contain_file_line('ensure /dev/shm fstab entry exists (nosuid)')
           end
         }
       end


### PR DESCRIPTION
## Summary
Found while enabling `dev_shm_nodev`/`dev_shm_noexec`/`dev_shm_nosuid` downstream: `/dev/shm` is normally kernel/systemd-mounted with **no** `/etc/fstab` entry on a stock system (confirmed default state on both Ubuntu 22.04 and 24.04). `set_mount_options` requires an *existing* fstab line to edit via Augeas — without one, these three classes fail outright at apply time:

```
Error: .../Augeas[/etc/fstab - work on /dev/shm with nodev]: Could not evaluate: Error sending command 'ins' with params [...]
```

This isn't a niche case — it's the default state for `/dev/shm` on most systems, so any consumer enabling these three rules on a stock host would hit this.

The module's own specs for these three classes only assert catalog compilation (rspec-puppet is compile-time only) and never caught this, since it's a runtime-only failure mode that only manifests when the Augeas provider actually runs against a real `/etc/fstab`.

## Fix
Added a `file_line` prerequisite in each of the three classes that creates a baseline `/dev/shm` entry only if one doesn't already exist (`append_on_no_match: true`), explicitly ordered (`before`) ahead of the mount-option edit. `replace: false` so any pre-existing custom entry (e.g. a configured size) is left completely untouched, not overwritten.

Scoped to just these three classes rather than the shared `set_mount_options` define, since that define is used by ~15 other rule classes for mountpoints (`/var`, `/home`, `/var/log`, etc.) that are typically real, already-fstab'd partitions — a generic "create a tmpfs baseline line" fallback there would be wrong for those.

## Test plan
- [x] `bundle exec rspec spec/classes/rules/dev_shm_{nodev,noexec,nosuid}_spec.rb` — 85 examples, 0 failures (added assertions for the new `file_line` resource and its ordering)
- [x] `bundle exec rake validate` — clean
- [x] `bundle exec rake lint` — clean
- [x] `bundle exec rake rubocop` — 461 files inspected, no offenses
- [x] `bundle exec rake spec` (full suite) — 15774 examples, 0 failures

Functional verification — built Ubuntu 24.04 and 22.04 containers with real Puppet 8 and the actual updated classes:
- [x] Reproduced the original failure first (no fstab entry, exit 4, real errors) to confirm the bug was real
- [x] With the fix: fresh container, no existing `/dev/shm` fstab entry — all three classes now apply cleanly (only the first-evaluated class's `file_line` actually creates the entry; the other two find it already present and no-op harmlessly, no conflicts between the three independently-declared `file_line` resources)
- [x] Idempotent on re-apply (exit 0, no changes)
- [x] Confirmed a pre-existing custom entry (tested with `size=2G`) is preserved untouched, with the new options appended on top

Re-verified everything above a second time using **OpenVox 8.28.1** (matching this repo's own pinned `Gemfile.lock` version and what actually runs in production) instead of Puppet Inc.'s agent, on both Ubuntu 22.04 and 24.04 — identical results across the board (same fstab output, same idempotency, same custom-entry preservation).