### PR TITLE
Fix `dev_shm` behavior

### DIFF
--- a/manifests/rules/dev_shm.pp
+++ b/manifests/rules/dev_shm.pp
@@ -28,19 +28,35 @@ class cis_security_hardening::rules::dev_shm (
   Integer $size    = 0,
 ) {
   if $enforce {
-    if $size == 0 {
-      $options = 'defaults,nodev,nosuid,noexec,seclabel'
-    } else {
-      $options = "defaults,size=${size}G,nodev,nosuid,noexec,seclabel"
+    # Create the entry only when missing; nodev, nosuid and noexec are added by their own rules
+    augeas { 'add /dev/shm to fstab':
+      context => '/files/etc/fstab',
+      changes => [
+        'set 01/spec tmpfs',
+        'set 01/file /dev/shm',
+        'set 01/vfstype tmpfs',
+        'set 01/opt defaults',
+        'set 01/dump 0',
+        'set 01/passno 0',
+      ],
+      onlyif  => "match *[file = '/dev/shm'] size == 0",
     }
 
-    $line = "tmpfs   /dev/shm        tmpfs   ${options}   0 0"
-    file_line { 'add /dev/shm to fstab':
-      ensure             => present,
-      path               => '/etc/fstab',
-      match              => "^tmpfs\\s* /dev/shm",
-      line               => $line,
-      append_on_no_match => true,
+    if $size > 0 {
+      cis_security_hardening::set_mount_options { '/dev/shm-size':
+        mountpoint   => '/dev/shm',
+        mountoptions => "size=${size}G",
+        require      => Augeas['add /dev/shm to fstab'],
+      }
+    }
+
+    # seclabel is only a valid mount option where SELinux is active
+    if fact('os.selinux.enabled') {
+      cis_security_hardening::set_mount_options { '/dev/shm-seclabel':
+        mountpoint   => '/dev/shm',
+        mountoptions => 'seclabel',
+        require      => Augeas['add /dev/shm to fstab'],
+      }
     }
   }
 }

--- a/manifests/set_mount_options.pp
+++ b/manifests/set_mount_options.pp
@@ -18,13 +18,33 @@ define cis_security_hardening::set_mount_options (
   Cis_security_hardening::Mountpoint $mountpoint,
   Cis_security_hardening::Mountoption $mountoptions,
 ) {
-  augeas { "/etc/fstab - work on ${mountpoint} with ${mountoptions}":
-    context => '/files/etc/fstab',
-    changes => [
+  # The fstab lens stores "size=2G" as opt = 'size' with a child value = '2G', never with the '='
+  $parts   = split($mountoptions, '=')
+  $optname = $parts[0]
+
+  if length($parts) > 1 {
+    $optvalue = join($parts[1, -1], '=')
+
+    # Append before dropping the stale key so opt[last()] stays valid
+    $changes = [
+      "ins opt after /files/etc/fstab/*[file = '${mountpoint}']/opt[last()]",
+      "set *[file = '${mountpoint}']/opt[last()] ${optname}",
+      "set *[file = '${mountpoint}']/opt[last()]/value ${optvalue}",
+      "rm *[file = '${mountpoint}']/opt[. = '${optname}'][value != '${optvalue}']",
+    ]
+    $onlyif = "match *[file = '${mountpoint}']/opt[. = '${optname}'][value = '${optvalue}'] size == 0"
+  } else {
+    $changes = [
       "ins opt after /files/etc/fstab/*[file = '${mountpoint}']/opt[last()]",
       "set *[file = '${mountpoint}']/opt[last()] ${mountoptions}",
-    ],
-    onlyif  => "match *[file = '${mountpoint}']/opt[. = '${mountoptions}'] size == 0",
+    ]
+    $onlyif = "match *[file = '${mountpoint}']/opt[. = '${mountoptions}'] size == 0"
+  }
+
+  augeas { "/etc/fstab - work on ${mountpoint} with ${mountoptions}":
+    context => '/files/etc/fstab',
+    changes => $changes,
+    onlyif  => $onlyif,
     notify  => Exec["remount ${mountpoint} with ${mountoptions}"],
   }
 

--- a/spec/acceptance/cis_security_hardening_spec.rb
+++ b/spec/acceptance/cis_security_hardening_spec.rb
@@ -18,5 +18,27 @@ describe 'cis_security_hardening class' do
     it 'is idempotent' do
       apply_manifest(pp, catch_changes: true)
     end
+
+    describe 'dev_shm rules' do
+      it 'adds exactly one /dev/shm entry to fstab' do
+        expect(shell('grep -c "[[:space:]]/dev/shm[[:space:]]" /etc/fstab').stdout.strip).to eq('1')
+      end
+
+      %w[nodev nosuid noexec].each do |opt|
+        it "sets #{opt} on the /dev/shm fstab entry" do
+          expect(shell('grep "[[:space:]]/dev/shm[[:space:]]" /etc/fstab').stdout).to match(%r{[,\s]#{opt}[,\s]})
+        end
+
+        it "applies #{opt} to the running /dev/shm mount" do
+          expect(shell('findmnt -no OPTIONS /dev/shm').stdout).to match(%r{\b#{opt}\b})
+        end
+      end
+
+      it 'does not write seclabel where SELinux is inactive' do
+        selinux = shell('getenforce 2>/dev/null || true').stdout.strip
+        skip 'SELinux is active' unless selinux.empty? || selinux == 'Disabled'
+        expect(shell('grep "[[:space:]]/dev/shm[[:space:]]" /etc/fstab').stdout).not_to match(%r{seclabel})
+      end
+    end
   end
 end

--- a/spec/acceptance/hieradata/common.yaml
+++ b/spec/acceptance/hieradata/common.yaml
@@ -11,10 +11,6 @@ cis_security_hardening::auto_reboot: false
 cis_security_hardening::rules::apparmor_bootloader::enforce: false
 cis_security_hardening::rules::authselect::enforce: false
 cis_security_hardening::rules::chrony::enforce: false
-cis_security_hardening::rules::dev_shm::enforce: false
-cis_security_hardening::rules::dev_shm_nodev::enforce: false
-cis_security_hardening::rules::dev_shm_noexec::enforce: false
-cis_security_hardening::rules::dev_shm_nosuid::enforce: false
 cis_security_hardening::rules::enable_aslr::enforce: false
 cis_security_hardening::rules::ptrace_scope::enforce: false
 cis_security_hardening::rules::restrict_core_dumps::enforce: false

--- a/spec/classes/rules/dev_shm_spec.rb
+++ b/spec/classes/rules/dev_shm_spec.rb
@@ -3,37 +3,119 @@
 require 'spec_helper'
 
 enforce_options = [true, false]
+size_options = [0, 2]
+
+create_changes = [
+  'set 01/spec tmpfs',
+  'set 01/file /dev/shm',
+  'set 01/vfstype tmpfs',
+  'set 01/opt defaults',
+  'set 01/dump 0',
+  'set 01/passno 0',
+]
 
 describe 'cis_security_hardening::rules::dev_shm' do
   on_supported_os.each do |os, os_facts|
     enforce_options.each do |enforce|
-      context "on #{os} with enforce = #{enforce}" do
-        let(:params) do
-          {
-            'enforce' => enforce,
-            'size'    => 2,
+      size_options.each do |size|
+        context "on #{os} with enforce = #{enforce} and size = #{size}" do
+          let(:params) do
+            {
+              'enforce' => enforce,
+              'size'    => size,
+            }
+          end
+
+          let(:facts) { os_facts }
+
+          it {
+            is_expected.to compile
+
+            is_expected.not_to contain_file_line('add /dev/shm to fstab')
+
+            if enforce
+              is_expected.to contain_augeas('add /dev/shm to fstab').
+                with(
+                  'context' => '/files/etc/fstab',
+                  'changes' => create_changes,
+                  'onlyif'  => "match *[file = '/dev/shm'] size == 0"
+                )
+
+              if size > 0
+                is_expected.to contain_cis_security_hardening__set_mount_options('/dev/shm-size').
+                  with(
+                    'mountpoint'   => '/dev/shm',
+                    'mountoptions' => "size=#{size}G"
+                  ).
+                  that_requires('Augeas[add /dev/shm to fstab]')
+              else
+                is_expected.not_to contain_cis_security_hardening__set_mount_options('/dev/shm-size')
+              end
+
+              if os_facts.dig(:os, 'selinux', 'enabled')
+                is_expected.to contain_cis_security_hardening__set_mount_options('/dev/shm-seclabel').
+                  with(
+                    'mountpoint'   => '/dev/shm',
+                    'mountoptions' => 'seclabel'
+                  ).
+                  that_requires('Augeas[add /dev/shm to fstab]')
+              else
+                is_expected.not_to contain_cis_security_hardening__set_mount_options('/dev/shm-seclabel')
+              end
+            else
+              is_expected.not_to contain_augeas('add /dev/shm to fstab')
+              is_expected.not_to contain_cis_security_hardening__set_mount_options('/dev/shm-size')
+              is_expected.not_to contain_cis_security_hardening__set_mount_options('/dev/shm-seclabel')
+            end
           }
         end
+      end
+    end
 
-        let(:facts) { os_facts }
+    context "on #{os} with enforce = true alongside the option rules" do
+      let(:pre_condition) do
+        <<-EOF
+          class { 'cis_security_hardening::rules::dev_shm_nodev':  enforce => true }
+          class { 'cis_security_hardening::rules::dev_shm_nosuid': enforce => true }
+          class { 'cis_security_hardening::rules::dev_shm_noexec': enforce => true }
+        EOF
+      end
 
-        it {
-          is_expected.to compile
-          if enforce
-            is_expected.to contain_file_line('add /dev/shm to fstab').
-              with(
-                'ensure'             => 'present',
-                'path'               => '/etc/fstab',
-                'match'              => '^tmpfs\\s* /dev/shm',
-                'line'               => 'tmpfs   /dev/shm        tmpfs   defaults,size=2G,nodev,nosuid,noexec,seclabel   0 0',
-                'append_on_no_match' => true
-              )
-          else
-            is_expected.not_to contain_cis_security_hardening__set_mount_options('/dev/shm')
-            is_expected.not_to contain_file_line('add /dev/shm to fstab')
-          end
+      let(:params) do
+        {
+          'enforce' => true,
+          'size'    => 0,
         }
       end
+
+      let(:facts) do
+        os_facts.merge(
+          mountpoints: {
+            '/dev/shm': {
+              available: '1.85 GiB',
+            },
+          }
+        )
+      end
+
+      it {
+        is_expected.to compile
+
+        %w[nodev nosuid noexec].each do |opt|
+          is_expected.to contain_cis_security_hardening__set_mount_options("/dev/shm-#{opt}").
+            with('mountpoint' => '/dev/shm', 'mountoptions' => opt)
+
+          is_expected.to contain_augeas("/etc/fstab - work on /dev/shm with #{opt}").
+            with(
+              'changes' => [
+                "ins opt after /files/etc/fstab/*[file = '/dev/shm']/opt[last()]",
+                "set *[file = '/dev/shm']/opt[last()] #{opt}",
+              ],
+              'onlyif' => "match *[file = '/dev/shm']/opt[. = '#{opt}'] size == 0"
+            ).
+            that_requires('Augeas[add /dev/shm to fstab]')
+        end
+      }
     end
   end
 end

--- a/spec/defines/set_mount_options_spec.rb
+++ b/spec/defines/set_mount_options_spec.rb
@@ -23,14 +23,29 @@ mpts.each do |mpt|
             is_expected.to compile
             aug = "/etc/fstab - work on #{mpt} with #{opt}"
             exc = "Exec[remount #{mpt} with #{opt}]"
+
+            if opt.include?('=')
+              optname, optvalue = opt.split('=', 2)
+              expected_changes = [
+                "ins opt after /files/etc/fstab/*[file = '#{mpt}']/opt[last()]",
+                "set *[file = '#{mpt}']/opt[last()] #{optname}",
+                "set *[file = '#{mpt}']/opt[last()]/value #{optvalue}",
+                "rm *[file = '#{mpt}']/opt[. = '#{optname}'][value != '#{optvalue}']",
+              ]
+              expected_onlyif = "match *[file = '#{mpt}']/opt[. = '#{optname}'][value = '#{optvalue}'] size == 0"
+            else
+              expected_changes = [
+                "ins opt after /files/etc/fstab/*[file = '#{mpt}']/opt[last()]",
+                "set *[file = '#{mpt}']/opt[last()] #{opt}",
+              ]
+              expected_onlyif = "match *[file = '#{mpt}']/opt[. = '#{opt}'] size == 0"
+            end
+
             is_expected.to contain_augeas(aug).
               with(
                 'context' => '/files/etc/fstab',
-                'changes' => [
-                  "ins opt after /files/etc/fstab/*[file = '#{mpt}']/opt[last()]",
-                  "set *[file = '#{mpt}']/opt[last()] #{opt}",
-                ],
-                'onlyif' => "match *[file = '#{mpt}']/opt[. = '#{opt}'] size == 0"
+                'changes' => expected_changes,
+                'onlyif'  => expected_onlyif
               ).
               that_notifies(exc)
 


### PR DESCRIPTION
#### Pull Request (PR) description

Fix `dev_shm` mounting:

* `rules::dev_shm` use augeas instead of file_line, with only defaults flag
* `set_mount_options` handle key=value pairs properly
* update specs
* enable acceptance tests

#### This Pull Request (PR) fixes the following issues

Fixes https://github.com/bwitt/cis_security_hardening/issues/77
