### PR TITLE
Fix use_authok typo to use_authtok in pam_old_passwords

### DIFF
--- a/files/pam_lockout/debian/common-password
+++ b/files/pam_lockout/debian/common-password
@@ -1,6 +1,6 @@
 password        requisite                       pam_pwquality.so retry=3
-password        required                        pam_pwhistory.so use_authok remember=5
-password        [success=1 default=ignore]      pam_unix.so obscure use_authok try_first_pass
+password        required                        pam_pwhistory.so use_authtok remember=5
+password        [success=1 default=ignore]      pam_unix.so obscure use_authtok try_first_pass
 password        requisite                       pam_deny.so
 password        required                        pam_permit.so
 password        optional                        pam_gnome_keyring.so

--- a/files/pam_lockout/ubuntu/common-password
+++ b/files/pam_lockout/ubuntu/common-password
@@ -1,6 +1,6 @@
 password        requisite                       pam_pwquality.so retry=3
-password        required                        pam_pwhistory.so use_authok remember=5
-password        [success=1 default=ignore]      pam_unix.so obscure use_authok try_first_pass
+password        required                        pam_pwhistory.so use_authtok remember=5
+password        [success=1 default=ignore]      pam_unix.so obscure use_authtok try_first_pass
 password        requisite                       pam_deny.so
 password        required                        pam_permit.so
 password        optional                        pam_gnome_keyring.so

--- a/manifests/rules/pam_old_passwords.pp
+++ b/manifests/rules/pam_old_passwords.pp
@@ -133,7 +133,7 @@ class cis_security_hardening::rules::pam_old_passwords (
             control   => 'required',
             module    => 'pam_pwhistory.so',
             position  => 'before *[type="password" and module="pam_unix.so"]',
-            arguments => ['use_authok', "remember=${oldpasswords}"],
+            arguments => ['use_authtok', "remember=${oldpasswords}"],
           }
         } elsif ($facts['os']['name'].downcase() == 'ubuntu' and $facts['os']['release']['major'] >= '20') {
           Pam { 'ubuntu-remember-old-pw':
@@ -143,7 +143,7 @@ class cis_security_hardening::rules::pam_old_passwords (
             control          => '[success=1 default=ignore]',
             control_is_param => true,
             module           => 'pam_unix.so',
-            arguments        => ['obscure', 'use_authok', 'try_first_pass', 'yescrypt', "remember=${oldpasswords}"],
+            arguments        => ['obscure', 'use_authtok', 'try_first_pass', 'yescrypt', "remember=${oldpasswords}"],
             position         => 'before *[type="password" and module="pam_deny.so"]',
           }
         } else {

--- a/spec/classes/rules/pam_old_passwords_spec.rb
+++ b/spec/classes/rules/pam_old_passwords_spec.rb
@@ -69,7 +69,7 @@ describe 'cis_security_hardening::rules::pam_old_passwords' do
                   'control'   => 'required',
                   'module'    => 'pam_pwhistory.so',
                   'position'  => 'before *[type="password" and module="pam_unix.so"]',
-                  'arguments' => ['use_authok', 'remember=5']
+                  'arguments' => ['use_authtok', 'remember=5']
                 )
               elsif os_facts[:os]['name'].casecmp('ubuntu').zero? && os_facts[:os]['release']['major'].to_i >= 20
                 is_expected.to contain_pam('ubuntu-remember-old-pw').with(
@@ -79,7 +79,7 @@ describe 'cis_security_hardening::rules::pam_old_passwords' do
                   'control'          => '[success=1 default=ignore]',
                   'control_is_param' => true,
                   'module'           => 'pam_unix.so',
-                  'arguments'        => ['obscure', 'use_authok', 'try_first_pass', 'yescrypt', 'remember=5'],
+                  'arguments'        => ['obscure', 'use_authtok', 'try_first_pass', 'yescrypt', 'remember=5'],
                   'position'         => 'before *[type="password" and module="pam_deny.so"]'
                 )
               else


### PR DESCRIPTION
## Summary
- `pam_old_passwords` passes `use_authok` (missing the `t`) as a PAM argument to `pam_pwhistory.so` and `pam_unix.so` on Debian>10 / Ubuntu 20.04+. PAM doesn't recognize `use_authok`, so it's silently ignored — the intended `use_authtok` behavior never takes effect on these paths.
- The static `files/pam_lockout/{debian,ubuntu}/common-password` templates ship the same typo.
- Scope note: there's a related but distinct typo (`use_auth_ok`, extra underscore) in the RHEL/Alma/Rocky branch of the same file — left out of this PR since it's a different OS family/code path; happy to follow up separately if useful.

## Verification that this is a real (not cosmetic) bug

**Documentation:** Linux-PAM's `pam_unix(8)` and `pam_pwhistory(8)` man pages list `use_authtok` as a recognized argument for both modules. `use_authok` doesn't appear in either man page.

**Binary proof:** `strings` on the actual compiled `pam_unix.so` / `pam_pwhistory.so` shipped in Ubuntu 22.04's `libpam-modules` / `libpam-pwquality` packages shows the argument parser matches the literal string `use_authtok`. The string `use_authok` does not exist anywhere in either binary, so it can never match — it's structurally a no-op, not just "probably unrecognized."

**Runtime proof:** ran an actual `passwd` change against the module's exact `common-password` stack in an Ubuntu 22.04 container, once with today's `use_authok` and once with `use_authtok`.

Current (buggy) stack — `/var/log/auth.log`:
```
pam_pwhistory(passwd:chauthtok): pam_pwhistory: unknown option: use_authok
pam_unix(passwd:chauthtok): unrecognized option [use_authok]
```
(each line appears twice — once for PAM's PRELIM_CHECK pass, once for UPDATE — expected PAM behavior, not a separate issue)

Fixed stack — clean log, no warnings, just the normal "password changed" lines.

So this is confirmed at three independent levels (docs, compiled binary, and live runtime behavior on the actual target OS) rather than being a stylistic guess.

## Test plan
- [x] `bundle exec rake fixtures:prep && bundle exec rspec spec/classes/rules/pam_old_passwords_spec.rb` — 29 examples, 0 failures (updated the two assertions that had hardcoded the typo)
- [x] Repo-wide grep confirms no remaining `authok` occurrences outside the intentionally-scoped `use_auth_ok` variant
- [x] Real `passwd` change against the actual `common-password` PAM stack on Ubuntu 22.04, comparing `use_authok` vs `use_authtok` — see verification section above