### PR TITLE
Add maxrepeat/maxsequence/enforce_for_root support on Debian family

### DIFF
--- a/manifests/rules/pam_old_passwords.pp
+++ b/manifests/rules/pam_old_passwords.pp
@@ -126,6 +126,11 @@ class cis_security_hardening::rules::pam_old_passwords (
       'debian', 'suse': {
         if ($facts['os']['name'].downcase() == 'debian' and $facts['os']['release']['major'] > '10') or
         ($facts['os']['name'].downcase() == 'ubuntu' and $facts['os']['release']['major'] >= '22') {
+          $pwhistory_arguments = $enforce_for_root ? {
+            true    => ['use_authtok', 'enforce_for_root', "remember=${oldpasswords}"],
+            default => ['use_authtok', "remember=${oldpasswords}"],
+          }
+
           Pam { 'pam-common-password-requisite-pwhistory':
             ensure    => present,
             service   => 'common-password',
@@ -133,7 +138,7 @@ class cis_security_hardening::rules::pam_old_passwords (
             control   => 'required',
             module    => 'pam_pwhistory.so',
             position  => 'before *[type="password" and module="pam_unix.so"]',
-            arguments => ['use_authtok', "remember=${oldpasswords}"],
+            arguments => $pwhistory_arguments,
           }
         } elsif ($facts['os']['name'].downcase() == 'ubuntu' and $facts['os']['release']['major'] >= '20') {
           Pam { 'ubuntu-remember-old-pw':

--- a/manifests/rules/pam_pw_requirements.pp
+++ b/manifests/rules/pam_pw_requirements.pp
@@ -379,6 +379,26 @@ class cis_security_hardening::rules::pam_pw_requirements (
           }
         }
 
+        if $maxrepeat > 0 {
+          file_line { 'pam maxrepeat debian':
+            ensure             => 'present',
+            path               => '/etc/security/pwquality.conf',
+            line               => "maxrepeat = ${maxrepeat}",
+            match              => '^#? ?maxrepeat',
+            append_on_no_match => true,
+          }
+        }
+
+        if $maxsequence > 0 {
+          file_line { 'pam maxsequence debian':
+            ensure             => 'present',
+            path               => '/etc/security/pwquality.conf',
+            line               => "maxsequence = ${maxsequence}",
+            match              => '^#? ?maxsequence',
+            append_on_no_match => true,
+          }
+        }
+
         if $usercheck {
           file_line { 'pam usercheck debian':
             ensure             => 'present',

--- a/spec/classes/rules/pam_old_passwords_spec.rb
+++ b/spec/classes/rules/pam_old_passwords_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 
 enforce_options = [true, false]
+enforce_for_root_options = [true, false]
 
 describe 'cis_security_hardening::rules::pam_old_passwords' do
   let(:pre_condition) do
@@ -17,90 +18,98 @@ describe 'cis_security_hardening::rules::pam_old_passwords' do
 
   on_supported_os.each do |os, os_facts|
     enforce_options.each do |enforce|
-      context "on #{os} with enforce = #{enforce}" do
-        let(:facts) do
-          os_facts.merge(
-            'cis_security_hardening' => {
-              'authselect' => {
-                'profile' => 'minimal',
-              },
+      enforce_for_root_options.each do |enforce_for_root|
+        context "on #{os} with enforce = #{enforce} and enforce_for_root = #{enforce_for_root}" do
+          let(:facts) do
+            os_facts.merge(
+              'cis_security_hardening' => {
+                'authselect' => {
+                  'profile' => 'minimal',
+                },
+              }
+            )
+          end
+          let(:params) do
+            {
+              'enforce'          => enforce,
+              'oldpasswords'     => 5,
+              'enforce_for_root' => enforce_for_root,
             }
-          )
-        end
-        let(:params) do
-          {
-            'enforce'      => enforce,
-            'oldpasswords' => 5,
+          end
+
+          it {
+            is_expected.to compile
+
+            if enforce
+              if os_facts[:os]['family'].casecmp('redhat').zero?
+                if os_facts[:os]['release']['major'] > '7'
+                  is_expected.to contain_exec('update authselect config for old passwords')
+                else
+                  is_expected.to contain_pam('pam-system-auth-pwhistory').with(
+                    'ensure'    => 'present',
+                    'service'   => 'system-auth',
+                    'type'      => 'password',
+                    'control'   => 'required',
+                    'module'    => 'pam_pwhistory.so',
+                    'arguments' => ['remember=5', 'use_auth_ok']
+                  )
+                  is_expected.to contain_pam('pam-password-auth-pwhistory').with(
+                    'ensure'    => 'present',
+                    'service'   => 'password-auth',
+                    'type'      => 'password',
+                    'control'   => 'required',
+                    'module'    => 'pam_pwhistory.so',
+                    'arguments' => ['remember=5', 'use_auth_ok']
+                  )
+                end
+              elsif os_facts[:os]['family'].casecmp('debian').zero? || os_facts[:os]['family'].casecmp('suse').zero?
+                if (os_facts[:os]['name'].casecmp('debian').zero? && os_facts[:os]['release']['major'].to_i > 10) ||
+                   (os_facts[:os]['name'].casecmp('ubuntu').zero? && os_facts[:os]['release']['major'].to_i >= 22)
+                  expected_arguments = if enforce_for_root
+                                         ['use_authtok', 'enforce_for_root', 'remember=5']
+                                       else
+                                         ['use_authtok', 'remember=5']
+                                       end
+                  is_expected.to contain_pam('pam-common-password-requisite-pwhistory').with(
+                    'ensure'    => 'present',
+                    'service'   => 'common-password',
+                    'type'      => 'password',
+                    'control'   => 'required',
+                    'module'    => 'pam_pwhistory.so',
+                    'position'  => 'before *[type="password" and module="pam_unix.so"]',
+                    'arguments' => expected_arguments
+                  )
+                elsif os_facts[:os]['name'].casecmp('ubuntu').zero? && os_facts[:os]['release']['major'].to_i >= 20
+                  is_expected.to contain_pam('ubuntu-remember-old-pw').with(
+                    'ensure'           => 'present',
+                    'service'          => 'common-password',
+                    'type'             => 'password',
+                    'control'          => '[success=1 default=ignore]',
+                    'control_is_param' => true,
+                    'module'           => 'pam_unix.so',
+                    'arguments'        => ['obscure', 'use_authtok', 'try_first_pass', 'yescrypt', 'remember=5'],
+                    'position'         => 'before *[type="password" and module="pam_deny.so"]'
+                  )
+                else
+                  is_expected.to contain_pam('pam-common-password-requisite-pwhistory').with(
+                    'ensure'    => 'present',
+                    'service'   => 'common-password',
+                    'type'      => 'password',
+                    'control'   => 'required',
+                    'module'    => 'pam_pwhistory.so',
+                    'arguments' => ['remember=5']
+                  )
+                end
+              end
+            else
+              is_expected.not_to contain_pam('pam-system-auth-sufficient')
+              is_expected.not_to contain_pam('pam-password-auth-sufficient')
+              is_expected.not_to contain_exec('update authselect config for old passwords')
+              is_expected.not_to contain_file('/etc/security/pwhistory.conf')
+              is_expected.not_to contain_file_line('pwhistory remember')
+            end
           }
         end
-
-        it {
-          is_expected.to compile
-
-          if enforce
-            if os_facts[:os]['family'].casecmp('redhat').zero?
-              if os_facts[:os]['release']['major'] > '7'
-                is_expected.to contain_exec('update authselect config for old passwords')
-              else
-                is_expected.to contain_pam('pam-system-auth-pwhistory').with(
-                  'ensure'    => 'present',
-                  'service'   => 'system-auth',
-                  'type'      => 'password',
-                  'control'   => 'required',
-                  'module'    => 'pam_pwhistory.so',
-                  'arguments' => ['remember=5', 'use_auth_ok']
-                )
-                is_expected.to contain_pam('pam-password-auth-pwhistory').with(
-                  'ensure'    => 'present',
-                  'service'   => 'password-auth',
-                  'type'      => 'password',
-                  'control'   => 'required',
-                  'module'    => 'pam_pwhistory.so',
-                  'arguments' => ['remember=5', 'use_auth_ok']
-                )
-              end
-            elsif os_facts[:os]['family'].casecmp('debian').zero? || os_facts[:os]['family'].casecmp('suse').zero?
-              if (os_facts[:os]['name'].casecmp('debian').zero? && os_facts[:os]['release']['major'].to_i > 10) ||
-                 (os_facts[:os]['name'].casecmp('ubuntu').zero? && os_facts[:os]['release']['major'].to_i >= 22)
-                is_expected.to contain_pam('pam-common-password-requisite-pwhistory').with(
-                  'ensure'    => 'present',
-                  'service'   => 'common-password',
-                  'type'      => 'password',
-                  'control'   => 'required',
-                  'module'    => 'pam_pwhistory.so',
-                  'position'  => 'before *[type="password" and module="pam_unix.so"]',
-                  'arguments' => ['use_authtok', 'remember=5']
-                )
-              elsif os_facts[:os]['name'].casecmp('ubuntu').zero? && os_facts[:os]['release']['major'].to_i >= 20
-                is_expected.to contain_pam('ubuntu-remember-old-pw').with(
-                  'ensure'           => 'present',
-                  'service'          => 'common-password',
-                  'type'             => 'password',
-                  'control'          => '[success=1 default=ignore]',
-                  'control_is_param' => true,
-                  'module'           => 'pam_unix.so',
-                  'arguments'        => ['obscure', 'use_authtok', 'try_first_pass', 'yescrypt', 'remember=5'],
-                  'position'         => 'before *[type="password" and module="pam_deny.so"]'
-                )
-              else
-                is_expected.to contain_pam('pam-common-password-requisite-pwhistory').with(
-                  'ensure'    => 'present',
-                  'service'   => 'common-password',
-                  'type'      => 'password',
-                  'control'   => 'required',
-                  'module'    => 'pam_pwhistory.so',
-                  'arguments' => ['remember=5']
-                )
-              end
-            end
-          else
-            is_expected.not_to contain_pam('pam-system-auth-sufficient')
-            is_expected.not_to contain_pam('pam-password-auth-sufficient')
-            is_expected.not_to contain_exec('update authselect config for old passwords')
-            is_expected.not_to contain_file('/etc/security/pwhistory.conf')
-            is_expected.not_to contain_file_line('pwhistory remember')
-          end
-        }
       end
     end
   end

--- a/spec/classes/rules/pam_pw_requirements_spec.rb
+++ b/spec/classes/rules/pam_pw_requirements_spec.rb
@@ -311,6 +311,24 @@ describe 'cis_security_hardening::rules::pam_pw_requirements' do
                   'append_on_no_match' => true
                 )
 
+              is_expected.to contain_file_line('pam maxrepeat debian').
+                with(
+                  'ensure' => 'present',
+                  'path' => '/etc/security/pwquality.conf',
+                  'line' => 'maxrepeat = 3',
+                  'match' => '^#? ?maxrepeat',
+                  'append_on_no_match' => true
+                )
+
+              is_expected.to contain_file_line('pam maxsequence debian').
+                with(
+                  'ensure' => 'present',
+                  'path' => '/etc/security/pwquality.conf',
+                  'line' => 'maxsequence = 3',
+                  'match' => '^#? ?maxsequence',
+                  'append_on_no_match' => true
+                )
+
               is_expected.to contain_file_line('pam usercheck debian').
                 with(
                   'ensure' => 'present',


### PR DESCRIPTION
## Summary
`pam_pw_requirements` and `pam_old_passwords` both have Debian branches that are missing behavior their RedHat branches already have:

- `pam_pw_requirements`'s Debian branch never writes `maxrepeat`/`maxsequence` to `/etc/security/pwquality.conf` — only the RedHat branch does, even though both params exist on the class and are documented.
- `pam_old_passwords`'s Debian/Ubuntu>=22 branch hardcodes its `Pam` resource arguments — `enforce_for_root` exists as a class param but is completely ignored on this OS family (it's only wired up in RedHat's older non-authselect path).

Found this while verifying CIS Ubuntu benchmark tickets (5.3.3.2.4, 5.3.3.2.5, 5.3.3.3.2) end-to-end — setting the params in Hiera had zero real effect on Ubuntu.

## Test plan
- [x] Real `puppet apply` in Docker (Ubuntu 24.04), before/after this fix, checked against the exact audit commands from the CIS tickets (not just resource existence):
  - **Before** (pinned commit `371fdb7`): `maxrepeat`/`maxsequence` never appear in `pwquality.conf`; `enforce_for_root` never appears on the `pam_pwhistory.so` line — ITCPE-625/628/631 audit scripts all FAIL
  - **After** (this branch): all three write correctly, idempotent on second apply — ITCPE-617/625/628/631 audit scripts all PASS
- [x] `bundle exec rspec spec/classes/rules/pam_pw_requirements_spec.rb spec/classes/rules/pam_old_passwords_spec.rb` — 85 examples, 0 failures (added coverage for the new debian-branch resources and the `enforce_for_root` on/off distinction)
- [x] `bundle exec rake lint` — clean
- [x] `bundle exec rubocop` — clean

<details>
<summary>Full puppet apply output — BEFORE fix (pinned commit 371fdb7, ITCPE-625/628/631 all FAIL)</summary>

```
debconf: delaying package configuration, since apt-utils is not installed
debconf: delaying package configuration, since apt-utils is not installed
=== facts driving hiera resolution ===
os.distro.id => Ubuntu
os.distro.release.major => 24.04

=== BEFORE: real pre-hardening state ===
--- pwquality.conf ---
# maxrepeat = 0
--- common-password ---
(no pam_pwhistory line yet)

=== puppet apply (real transition expected) ===
Notice: Scope(Class[main]): RESOLVED: pw_req_enforce=true maxrepeat=3 maxsequence=3 old_pw_enforce=true enforce_for_root=true
Notice: Compiled catalog for 500338ac1745.vdesk.cloud.aurora.tech in environment production in 0.11 seconds
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_old_passwords/Pam[pam-common-password-requisite-pwhistory]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam minlen]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam minclass]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam enforcing]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam dcredit]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam ucredit]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam ocredit]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam lcredit]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam difok]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam dictcheck]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam usercheck debian]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam gecoscheck debian]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam enforce_for_root debian]/ensure: created
Notice: Applied catalog in 0.96 seconds
exit code: 2 (expect 2: changes made)

=== AFTER: real applied config ===
--- pwquality.conf (maxrepeat / maxsequence) ---
# maxrepeat = 0
--- common-password (pam_pwhistory line, ITCPE-617 + ITCPE-631 audit target) ---
password required pam_pwhistory.so use_authtok remember=24

=== ITCPE-617 audit script (as written in the ticket) ===
password required pam_pwhistory.so use_authtok remember=24
PASS: pam_pwhistory.so present

=== ITCPE-631 audit script (as written in the ticket) ===
FAIL

=== ITCPE-625 audit script (maxrepeat in pwquality.conf, 1-3) ===
FAIL

=== ITCPE-628 audit script (maxsequence in pwquality.conf, 1-3) ===
FAIL

=== idempotency: second apply ===
Notice: Scope(Class[main]): RESOLVED: pw_req_enforce=true maxrepeat=3 maxsequence=3 old_pw_enforce=true enforce_for_root=true
Notice: Compiled catalog for 500338ac1745.vdesk.cloud.aurora.tech in environment production in 0.11 seconds
Notice: Applied catalog in 0.95 seconds
second run exit code: 0 (expect 0: no changes)
```

</details>

<details>
<summary>Full puppet apply output — AFTER fix (this branch, all four tickets PASS)</summary>

```
debconf: delaying package configuration, since apt-utils is not installed
debconf: delaying package configuration, since apt-utils is not installed
=== facts driving hiera resolution ===
os.distro.id => Ubuntu
os.distro.release.major => 24.04

=== BEFORE: real pre-hardening state ===
--- pwquality.conf ---
# maxrepeat = 0
--- common-password ---
(no pam_pwhistory line yet)

=== puppet apply (real transition expected) ===
Notice: Scope(Class[main]): RESOLVED: pw_req_enforce=true maxrepeat=3 maxsequence=3 old_pw_enforce=true enforce_for_root=true
Notice: Compiled catalog for 7ebc96da17a0.vdesk.cloud.aurora.tech in environment production in 0.11 seconds
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_old_passwords/Pam[pam-common-password-requisite-pwhistory]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam minlen]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam minclass]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam enforcing]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam dcredit]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam ucredit]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam ocredit]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam lcredit]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam difok]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam dictcheck]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam maxrepeat debian]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam maxsequence debian]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam usercheck debian]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam gecoscheck debian]/ensure: created
Notice: /Stage[main]/Cis_security_hardening::Rules::Pam_pw_requirements/File_line[pam enforce_for_root debian]/ensure: created
Notice: Applied catalog in 0.97 seconds
exit code: 2 (expect 2: changes made)

=== AFTER: real applied config ===
--- pwquality.conf (maxrepeat / maxsequence) ---
maxrepeat = 3
maxsequence = 3
--- common-password (pam_pwhistory line, ITCPE-617 + ITCPE-631 audit target) ---
password required pam_pwhistory.so use_authtok enforce_for_root remember=24

=== ITCPE-617 audit script (as written in the ticket) ===
password required pam_pwhistory.so use_authtok enforce_for_root remember=24
PASS: pam_pwhistory.so present

=== ITCPE-631 audit script (as written in the ticket) ===
password required pam_pwhistory.so use_authtok enforce_for_root remember=24
PASS: enforce_for_root present

=== ITCPE-625 audit script (maxrepeat in pwquality.conf, 1-3) ===
maxrepeat = 3
PASS

=== ITCPE-628 audit script (maxsequence in pwquality.conf, 1-3) ===
maxsequence = 3
PASS

=== idempotency: second apply ===
Notice: Scope(Class[main]): RESOLVED: pw_req_enforce=true maxrepeat=3 maxsequence=3 old_pw_enforce=true enforce_for_root=true
Notice: Compiled catalog for 7ebc96da17a0.vdesk.cloud.aurora.tech in environment production in 0.11 seconds
Notice: Applied catalog in 0.95 seconds
second run exit code: 0 (expect 0: no changes)
```

</details>